### PR TITLE
Expose host and port for request

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -20,7 +20,9 @@ var create_client = function(token, config) {
     
     metrics.config = {
         test: false,
-        debug: false
+        debug: false,
+        host: "api.mixpanel.com",
+        port: 80
     };
     
     metrics.token = token;
@@ -51,8 +53,8 @@ var create_client = function(token, config) {
         }
         
         var request_options = {
-            host: 'api.mixpanel.com',
-            port: 80,
+            host: metrics.config.host,
+            port: metrics.config.port,
             headers: {}
         };
     

--- a/test/config.js
+++ b/test/config.js
@@ -8,7 +8,7 @@ exports.config = {
 
     "is set to correct defaults": function(test) {
         test.deepEqual(this.mixpanel.config,
-                       { test: false, debug: false },
+                       { test: false, debug: false, host: "api.mixpanel.com", port: 80 },
                        "default config is incorrect");
         test.done();
     },


### PR DESCRIPTION
This allows the user to set an alternative host and port:

``` js
var client = Mixpanel.init("testing123");

client.set_config({host: "my-mixpanel-clone.com", port: 5000});
```
