### PR TITLE
Force requests to always use http

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -53,7 +53,8 @@ var create_client = function(token, config) {
         var request_options = {
             host: 'api.mixpanel.com',
             port: 80,
-            headers: {}
+            headers: {},
+            scheme: 'http'
         };
     
         if (metrics.config.test) { request_data.test = 1; }


### PR DESCRIPTION
A recent change to http-browserify defaults the scheme (http or https) for requests to the current page's scheme - https://github.com/substack/http-browserify/commit/e4a5316f34de17334df90bc5f20dc654c5fcc636

This would break sites that were using mixpanel-node on a https website, because Mixpanel does not support https.
