### PR TITLE
Handle the special property IP correctly when setting it on people profiles

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -183,6 +183,11 @@ var create_client = function(token, config) {
                 '$distinct_id': distinct_id
             }
 
+            if($set['ip']) {
+                data['$ip'] = $set['ip'];
+                delete $set['ip'];
+            }
+
             if(metrics.config.debug) {
                 console.log("Sending the following data to Mixpanel (Engage):");
                 console.log(data);

--- a/test/people.js
+++ b/test/people.js
@@ -54,6 +54,25 @@ exports.people = {
             );
 
             test.done();
+        },
+
+        "handles the ip property in a property object properly": function(test) {
+            var prop = { ip: '1.2.3.4', key1: 'val1', key2: 'val2' },
+                expected_data = {
+                    $set: { key1: 'val1', key2: 'val2' },
+                    $token: this.token,
+                    $distinct_id: this.distinct_id,
+                    $ip: '1.2.3.4'
+                };
+
+            this.mixpanel.people.set(this.distinct_id, prop);
+
+            test.ok(
+                this.mixpanel.send_request.calledWithMatch(this.endpoint, expected_data),
+                "people.set didn't call send_request with correct arguments"
+            );
+
+            test.done();
         }
     },
 


### PR DESCRIPTION
Mixpanel expects an optional IP property differently in their People REST API [1] and we have made a small change to reflect this. If an `ip` property is passed to `people.set`, it will be correctly extracted and passed as `$ip` to Mixpanel.

We are using this fork in production and have created thousands of people profiles since it has been rolled out and the profiles correctly get `Country`, `Region` and `City` properties set on them based on the IP address.

[1] https://mixpanel.com/docs/people-analytics/people-http-specification-insert-data
