### PR TITLE
Handle $ignore_time in people.set

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -188,6 +188,11 @@ var create_client = function(token, config) {
                 delete $set['ip'];
             }
 
+            if ($set['$ignore_time']) {
+                data['$ignore_time'] = $set['$ignore_time'];
+                delete $set['$ignore_time'];
+            }
+
             if(metrics.config.debug) {
                 console.log("Sending the following data to Mixpanel (Engage):");
                 console.log(data);

--- a/test/people.js
+++ b/test/people.js
@@ -73,6 +73,25 @@ exports.people = {
             );
 
             test.done();
+        },
+
+        "handles the $ignore_time property in a property object properly": function(test) {
+            var prop = { $ignore_time: true, key1: 'val1', key2: 'val2' },
+                expected_data = {
+                    $set: { key1: 'val1', key2: 'val2' },
+                    $token: this.token,
+                    $distinct_id: this.distinct_id,
+                    $ignore_time: true
+                };
+
+            this.mixpanel.people.set(this.distinct_id, prop);
+
+            test.ok(
+                this.mixpanel.send_request.calledWithMatch(this.endpoint, expected_data),
+                "people.set didn't call send_request with correct arguments"
+            );
+
+            test.done();
         }
     },
 


### PR DESCRIPTION
This supports importing older data without clobbering $last_seen, meaning that it can be set explicitly within the set properties.
