### PR TITLE
removed port specification

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -55,7 +55,6 @@ var create_client = function(token, config) {
 
         var request_options = {
             host: 'api.mixpanel.com',
-            port: 80,
             headers: {}
         };
 

--- a/test/send_request.js
+++ b/test/send_request.js
@@ -37,7 +37,6 @@ exports.send_request = {
 
         var expected_http_get = {
             host: 'api.mixpanel.com',
-            port: 80,
             headers: {},
             path: '/track?data=eyJldmVudCI6InRlc3QiLCJwcm9wZXJ0aWVzIjp7ImtleTEiOiJ2YWwxIiwidG9rZW4iOiJ0b2tlbiIsInRpbWUiOjEzNDY4NzY2MjF9fQ%3D%3D&ip=0&verbose=0'
         };


### PR DESCRIPTION
Hey there, 

Thanks for great module.    It has actually proved quite handy for use in a firefox & chrome extension, where mixpanel's normal javascript libraries won't work.   

The only issue I've run into, however, is the specification of port 80 on the http request; this prevents any requests to mixpanel from operating over https.   Since this is an optional parameter, I just removed it, and adjusted the tests accordingly. 

Steve
