### PR TITLE
added ability to specify request options via config

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -54,9 +54,11 @@ var create_client = function(token, config) {
         }
 
         var request_options = {
-            host: 'api.mixpanel.com',
+            host: 'api.mixpanel.com', 
             headers: {}
         };
+
+        request_options = _extend(request_options, metrics.config.request_options);
 
         if (metrics.config.test) { request_data.test = 1; }
 
@@ -518,12 +520,25 @@ var create_client = function(token, config) {
                             mixpanel client config
     */
     metrics.set_config = function(config) {
-        for (var c in config) {
-            if (config.hasOwnProperty(c)) {
-                metrics.config[c] = config[c];
+        metrics.config = _extend(metrics.config, config);
+    };
+
+    /**
+        _extend(obj1, obj2)
+        ---
+        Copies properties from obj2 to obj1
+    */
+
+    _extend = function(obj1, obj2) {
+        for (var prop in obj2) {
+            if (obj2.hasOwnProperty(prop)) {
+                obj1[prop] = obj2[prop];
             }
         }
+
+        return obj1;
     };
+
 
     if (config) {
         metrics.set_config(config);

--- a/test/send_request.js
+++ b/test/send_request.js
@@ -4,8 +4,26 @@ var Mixpanel    = require('../lib/mixpanel-node'),
     events      = require('events');
 
 exports.send_request = {
+
     setUp: function(next) {
         this.mixpanel = Mixpanel.init('token');
+
+        this.endpoint = "/track",
+        this.data = {
+                event: 'test',
+                properties: {
+                    key1: 'val1',
+                    token: 'token',
+                    time: 1346876621
+                }
+            };
+
+        this.expected_http_get = {
+            host: 'api.mixpanel.com',
+            headers: {},
+            path: '/track?data=eyJldmVudCI6InRlc3QiLCJwcm9wZXJ0aWVzIjp7ImtleTEiOiJ2YWwxIiwidG9rZW4iOiJ0b2tlbiIsInRpbWUiOjEzNDY4NzY2MjF9fQ%3D%3D&ip=0&verbose=0'
+        };
+
 
         Sinon.stub(http, 'get');
 
@@ -25,28 +43,23 @@ exports.send_request = {
     },
 
     "sends correct data": function(test) {
-        var endpoint = "/track",
-            data = {
-                event: 'test',
-                properties: {
-                    key1: 'val1',
-                    token: 'token',
-                    time: 1346876621
-                }
-            };
+        this.mixpanel.send_request(this.endpoint, this.data);
 
-        var expected_http_get = {
-            host: 'api.mixpanel.com',
-            headers: {},
-            path: '/track?data=eyJldmVudCI6InRlc3QiLCJwcm9wZXJ0aWVzIjp7ImtleTEiOiJ2YWwxIiwidG9rZW4iOiJ0b2tlbiIsInRpbWUiOjEzNDY4NzY2MjF9fQ%3D%3D&ip=0&verbose=0'
-        };
-
-        this.mixpanel.send_request(endpoint, data);
-
-        test.ok(http.get.calledWithMatch(expected_http_get), "send_request didn't call http.get with correct arguments");
+        test.ok(http.get.calledWithMatch(this.expected_http_get), "send_request didn't call http.get with correct arguments");
 
         test.done();
     },
+
+    "includes config parameters": function(test) {
+        this.mixpanel.set_config({ request_options: { scheme: 'test' } });
+        this.expected_http_get.scheme = 'test'
+
+        this.mixpanel.send_request(this.endpoint, this.data);
+        test.ok(http.get.calledWithMatch(this.expected_http_get), "send_request didn't call http.get with correct arguments");
+
+        test.done();
+    },
+
 
     "handles mixpanel errors": function(test) {
         test.expect(1);


### PR DESCRIPTION
this allows the consumer to supply additional options to the http.get request call by doing

```
   mixpanel.init('....', { request_options: { scheme: 'http' }});
```

The longer story is, i'm using the module from within a chrome extension.  That extension sometimes makes mixpanel calls from a window whose protocol is `chrome-extension://`.  Since no scheme is specified, `http` uses the document's scheme, so the request ends up being `chrome-extension://api.mixpanel.com...`.   fail.

Updated tests, everything still pases.

zeev
