### PR TITLE
Allow tracking of IP address

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -41,7 +41,7 @@ var create_client = function(token, config) {
         var event_data = new Buffer(JSON.stringify(data));
         var request_data = {
             'data': event_data.toString('base64'),
-            'ip': 0,
+            'ip': metrics.config.track_ip ? 1 : 0,
             'verbose': metrics.config.verbose ? 1 : 0
         };
 
@@ -59,7 +59,6 @@ var create_client = function(token, config) {
         };
 
         if (metrics.config.test) { request_data.test = 1; }
-        if (metrics.config.track_ip) { request_data.ip = 1; }
 
         var query = querystring.stringify(request_data);
 

--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -59,6 +59,7 @@ var create_client = function(token, config) {
         };
 
         if (metrics.config.test) { request_data.test = 1; }
+        if (metrics.config.track_ip) { request_data.ip = 1; }
 
         var query = querystring.stringify(request_data);
 

--- a/test/send_request.js
+++ b/test/send_request.js
@@ -48,6 +48,16 @@ exports.send_request = {
         test.done();
     },
 
+    "includes configured request data": function(test) {
+      this.mixpanel.set_config({ track_ip: true });
+
+      this.mixpanel.send_request("/track", { event: "test" });
+
+      test.ok(http.get.calledWithMatch({ path: Sinon.match('ip=1') }), "send_request didn't call http.get with correct request data");
+
+      test.done();
+    },
+
     "handles mixpanel errors": function(test) {
         test.expect(1);
         this.mixpanel.send_request("/track", { event: "test" }, function(e) {


### PR DESCRIPTION
Hi,

I was trying to track events with an `ip` attribute like [so](https://github.com/adorableio/adorable-avatars/blob/master/lib/webserver.coffee#L56-L65), but mixPanel was ignoring that attribute.

By setting the request's `ip` property to `1`, I was able to get mixPanel to use the event's IP for geoloc purposes. This is hinted at [here](https://mixpanel.com/help/reference/http), under the "Special properties in events" section.

I didn't see an option for setting this in your library, so I added one. This was a quick and dirty implementation; please let me know if you'd like me to change it. It was also unclear how/if something like this would be tested, so advice in that regard would be appreciated as well.

Thanks!