### PR TITLE
$ignore_time option on unset

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -469,18 +469,27 @@ var create_client = function(token, config) {
         },
 
         /**
-         people.unset(distinct_id, prop, callback)
+         people.unset(distinct_id, prop, updateLastSeen, callback)
          ---
          delete a property on an user record in engage
 
+         will update last seen by default
+         call with updateLastSeen = false to not update last seen
+         
          usage:
 
             mixpanel.people.unset('bob', 'page_views');
 
             mixpanel.people.unset('bob', ['page_views', 'last_login']);
          */
-        unset: function(distinct_id, prop, callback) {
+        unset: function(distinct_id, prop, updateLastSeen, callback) {
             var $unset = [];
+            
+            //backwards support for callback as 3rd arg
+            if (typeof(updateLastSeen) === 'function') {
+                callback = updateLastSeen;
+                updateLastSeen = false;
+            }
 
             if (util.isArray(prop)) {
                 $unset = prop;
@@ -499,7 +508,12 @@ var create_client = function(token, config) {
                 '$token': metrics.token,
                 '$distinct_id': distinct_id
             };
-
+            
+            if (updateLastSeen === false) {
+                data['$ignore_time'] = true;
+            }
+            
+            
             if(metrics.config.debug) {
                 console.log("Sending the following data to Mixpanel (Engage):");
                 console.log(data);


### PR DESCRIPTION
right now when you use the lib to unset to update the $last_seen of the people you are unsetting from.
this can be annoying...

option to ignore updating the $last_seen 