### PR TITLE
add support for extra options to append API

### DIFF
--- a/example.js
+++ b/example.js
@@ -45,6 +45,13 @@ mixpanel.people.append("billybob", "awards", "Great Player");
 // append multiple values to a list
 mixpanel.people.append("billybob", {"awards": "Great Player", "levels_finished": "Level 4"});
 
+// append multiple values to a list with callback
+var callback = function(err) { if (err) { throw err; }
+mixpanel.people.append("billybob", {"awards": "Great Player", "levels_finished": "Level 4"}, callback);
+
+// append multiple values to a list with options
+mixpanel.people.append("billybob", {"awards": "Great Player", "levels_finished": "Level 4"}, {"$ignore_time": true});
+
 // record a transaction for revenue analytics
 mixpanel.people.track_charge("billybob", 39.99);
 

--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -338,24 +338,40 @@ var create_client = function(token, config) {
             usage:
 
                 // append a value to a list, creating it if needed
-                mixpanel.people.append('pages_visited', 'homepage');
+                mixpanel.people.append('<USER_ID>', 'pages_visited', 'homepage', <MY_CALLBACK>, {"$ignore_time": true} );
 
                 // like mixpanel.people.set(), you can append multiple properties at once:
-                mixpanel.people.append({
-                    list1: 'bob',
-                    list2: 123
-                });
+                mixpanel.people.append(
+                    '<USER_ID>',
+                    {
+                        list1: 'bob',
+                        list2: 123
+                    },
+                    <MY_CALLBACK>,
+                    {"$ignore_time": true}
+                );
+
+                // opts can be: ['$ignored_time', '$ip', '$time']
+
+            docs: https://mixpanel.com/help/reference/http#people-analytics-updates
         */
-        append: function(distinct_id, prop, value, callback) {
+        append: function(distinct_id, prop, value, callback, opts) {
+
             var $append = {};
 
-            if (typeof(prop) === 'object') {
+            if (prop !== null && typeof prop === 'object') {
+                var original_callback = callback;
                 callback = value;
+                opts = original_callback;
                 Object.keys(prop).forEach(function(key) {
                     $append[key] = prop[key];
                 });
             } else {
                 $append[prop] = value;
+            }
+
+            if (callback !== null && typeof callback !== 'function') {
+                opts = callback;
             }
 
             var data = {
@@ -364,11 +380,16 @@ var create_client = function(token, config) {
                 '$distinct_id': distinct_id
             };
 
+            if (opts !== null && typeof opts === 'object') {
+                Object.keys(opts).forEach(function(key) {
+                    data[key] = opts[key];
+                });
+            }
+
             if(metrics.config.debug) {
                 console.log("Sending the following data to Mixpanel (Engage):");
                 console.log(data);
             }
-
             metrics.send_request('/engage', data, callback);
         },
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "lib": "lib"
   },
   "repository": {
-      "type": "git",
-      "url": "http://github.com/carlsverre/mixpanel-node.git"
+    "type": "git",
+    "url": "http://github.com/carlsverre/mixpanel-node.git"
   },
   "engines": {
     "node": ">=0.6.0"

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,16 @@ mixpanel.people.append("billybob", "awards", "Great Player");
 // append multiple values to a list
 mixpanel.people.append("billybob", {"awards": "Great Player", "levels_finished": "Level 4"});
 
+// append multiple values to a list with callback
+var callback = function(err) { if (err) { throw err; }
+mixpanel.people.append("billybob", {"awards": "Great Player", "levels_finished": "Level 4"}, callback);
+
+// append multiple values to a list with options
+mixpanel.people.append("billybob", {"awards": "Great Player", "levels_finished": "Level 4"}, {"$ignore_time": true});
+
+// record a transaction for revenue analytics
+mixpanel.people.track_charge("billybob", 39.99);
+
 // record a transaction for revenue analytics
 mixpanel.people.track_charge("billybob", 39.99);
 

--- a/test/people.js
+++ b/test/people.js
@@ -228,6 +228,31 @@ exports.people = {
             test.done();
         },
 
+        "supports singe key, value and extra options with callback": function(test) {
+            var prop = { key1: 'value1' },
+                expected_data = {
+                    $append: prop,
+                    $token: this.token,
+                    $distinct_id: this.distinct_id,
+                    $ignore_time: true
+                },
+                callback = function() {};
+
+            this.mixpanel.people.append(this.distinct_id, 'key1', 'value1', callback, {"$ignore_time": true});
+
+            test.ok(
+                this.mixpanel.send_request.args[0][2] === callback,
+                "people.set_once didn't call send_request with a callback"
+            );
+
+            test.ok(
+                this.mixpanel.send_request.calledWithMatch(this.endpoint, expected_data),
+                "people.append didn't call send_request with correct arguments"
+            );
+
+            test.done();
+        },
+
         "supports appending multiple keys with values": function(test) {
             var prop = { key1: 'value1', key2: 'value2' },
                 expected_data = {
@@ -237,6 +262,50 @@ exports.people = {
                 };
 
             this.mixpanel.people.append(this.distinct_id, prop);
+
+            test.ok(
+                this.mixpanel.send_request.calledWithMatch(this.endpoint, expected_data),
+                "people.append didn't call send_request with correct arguments"
+            );
+
+            test.done();
+        },
+
+        "supports extra options": function(test) {
+            var prop = { key1: 'value1', key2: 'value2' },
+                expected_data = {
+                    $append: prop,
+                    $token: this.token,
+                    $distinct_id: this.distinct_id,
+                    $ignore_time: true
+                };
+
+            this.mixpanel.people.append(this.distinct_id, prop, {"$ignore_time": true});
+
+            test.ok(
+                this.mixpanel.send_request.calledWithMatch(this.endpoint, expected_data),
+                "people.append didn't call send_request with correct arguments"
+            );
+
+            test.done();
+        },
+
+        "supports extra options with callback": function(test) {
+            var prop = { key1: 'value1', key2: 'value2' },
+                expected_data = {
+                    $append: prop,
+                    $token: this.token,
+                    $distinct_id: this.distinct_id,
+                    $ignore_time: true
+                },
+                callback = function() {};
+
+            this.mixpanel.people.append(this.distinct_id, prop, callback, {"$ignore_time": true});
+
+            test.ok(
+                this.mixpanel.send_request.args[0][2] === callback,
+                "people.set_once didn't call send_request with a callback"
+            );
 
             test.ok(
                 this.mixpanel.send_request.calledWithMatch(this.endpoint, expected_data),


### PR DESCRIPTION
Accepting `opts` to append API

Although `typeof opts === 'object'` is not the best way to check if opts is an object I would prefer to be consistent with the rest of the lib