### PR TITLE
Feature/unset to include ignore time

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -500,6 +500,11 @@ var create_client = function(token, config) {
                 '$distinct_id': distinct_id
             };
 
+            if ($unset.indexOf('$ignore_time') !== -1) {
+                data.$ignore_time = true;
+                $unset = $unset.splice($unset.indexOf('$ignore_time'), 1);
+            }
+
             if(metrics.config.debug) {
                 console.log("Sending the following data to Mixpanel (Engage):");
                 console.log(data);

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,9 @@ mixpanel.people.set("billybob", {
     points: 0
 });
 
+// unset properties and ignore the ‘last seen’ time update
+mixpanel.people.unset(“billybob”, [“key1”, “key2”, “$ignore_time”]);
+
 // set a single property on a user
 mixpanel.people.set("billybob", "plan", "free");
 

--- a/readme.md
+++ b/readme.md
@@ -38,8 +38,8 @@ mixpanel.people.set("billybob", {
     points: 0
 });
 
-// unset properties and ignore the ‘last seen’ time update
-mixpanel.people.unset(“billybob”, [“key1”, “key2”, “$ignore_time”]);
+// unset properties and ignore the "last seen" time update
+mixpanel.people.unset("billybob", ["key1", "key2", "$ignore_time"]);
 
 // set a single property on a user
 mixpanel.people.set("billybob", "plan", "free");
@@ -67,7 +67,7 @@ mixpanel.people.clear_charges("billybob");
 
 // delete a user
 mixpanel.people.delete_user("billybob");
- 
+
 // Create an alias for an existing distinct id
 mixpanel.alias("distinct_id", "your_alias");
 

--- a/test/people.js
+++ b/test/people.js
@@ -371,7 +371,26 @@ exports.people = {
             );
 
             test.done();
-        }
+        },
+
+        "handles the $ignore_time property in a property object properly": function(test) {
+            var prop = ['$ignore_time', 'key1', 'key2'],
+                expected_data = {
+                    $unset: ['key1', 'key2'],
+                    $token: this.token,
+                    $distinct_id: this.distinct_id,
+                    $ignore_time: true
+                };
+
+            this.mixpanel.people.unset(this.distinct_id, prop);
+
+            test.ok(
+                this.mixpanel.send_request.calledWithMatch(this.endpoint, expected_data),
+                "people.unset didn't call send_request with correct arguments"
+            );
+
+            test.done();
+        },
     }
 
 


### PR DESCRIPTION
A possible fix to https://github.com/mixpanel/mixpanel-node/issues/51. Adding the `$ignore_time` to the list of properties to unset would be the easiest solution.