### PR TITLE
Allow to call track_charge with a callback and without a properties object.

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -390,6 +390,10 @@ var create_client = function(token, config) {
             var $append = {};
 
             if (!properties) { properties = {}; }
+            if (typeof properties === 'function') {
+                callback = properties;
+                properties = {};
+            }
 
             if (typeof(amount) !== 'number') {
                 amount = parseFloat(amount);

--- a/test/people.js
+++ b/test/people.js
@@ -284,6 +284,42 @@ exports.people = {
             );
 
             test.done();
+        },
+
+        "supports being called with a callback": function(test) {
+            var expected_data = {
+                    $append: { $transactions: { $amount: 50 } },
+                    $token: this.token,
+                    $distinct_id: this.distinct_id
+                };
+
+            var callback = function() {};
+            this.mixpanel.people.track_charge(this.distinct_id, 50, callback);
+
+            test.ok(
+                this.mixpanel.send_request.args[0][2] === callback,
+                "people.track_charge didn't call send_request with correct arguments"
+            );
+
+            test.done();
+        },
+
+        "supports being called with properties and a callback": function(test) {
+            var expected_data = {
+                    $append: { $transactions: { $amount: 50 } },
+                    $token: this.token,
+                    $distinct_id: this.distinct_id
+                };
+
+            var callback = function() {};
+            this.mixpanel.people.track_charge(this.distinct_id, 50, {}, callback);
+
+            test.ok(
+                this.mixpanel.send_request.args[0][2] === callback,
+                "people.track_charge didn't call send_request with correct arguments"
+            );
+
+            test.done();
         }
     },
 


### PR DESCRIPTION
If you do this

```js
mixpanel.people.track_charge(id, 50, callback);
```

It doesn't ever call the callback, and also doesn't throw or errors. This PR fixes it and adds a test case for it.