### PR TITLE
fix for delete_user, data.$delete should be empty string

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -566,7 +566,7 @@ var create_client = function(token, config) {
         */
         delete_user: function(distinct_id, callback) {
             var data = {
-                '$delete': distinct_id,
+                '$delete': '',
                 '$token': metrics.token,
                 '$distinct_id': distinct_id
             };

--- a/test/people.js
+++ b/test/people.js
@@ -345,7 +345,7 @@ exports.people = {
     delete_user: {
         "calls send_request with correct endpoint and data": function(test) {
             var expected_data = {
-                    $delete: this.distinct_id,
+                    $delete: '',
                     $token: this.token,
                     $distinct_id: this.distinct_id
                 };


### PR DESCRIPTION
you get a success response from mixpanel if `data.$delete` is set to `distinct_id` however the user is not deleted. It should be an empty string, as described in the [http api reference](https://mixpanel.com/help/reference/http)