### PR TITLE
return null to the callback for no errors, rather than empty array

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -257,7 +257,11 @@ var create_client = function(token, config) {
                     if (completed_events < total_events) {
                         send_next_batch();
                     } else if (callback) {
-                        callback(request_errors);
+                        if (request_errors.length == 0) {
+                          callback(null);
+                        } else {
+                          callback(request_errors);
+                        }
                     }
                 });
                 event_group_idx += batch_size;

--- a/test/import.js
+++ b/test/import.js
@@ -193,7 +193,7 @@ exports.import_batch_integration = {
                 "import_batch didn't call send_request correct number of times before callback"
             );
             test.equals(
-                0, error_list.length,
+                null, error_list,
                 "import_batch returned errors in callback unexpectedly"
             );
             test.done();
@@ -227,7 +227,7 @@ exports.import_batch_integration = {
                 "import_batch didn't call send_request correct number of times before callback"
             );
             test.equals(
-                0, error_list.length,
+                null, error_list,
                 "import_batch returned errors in callback unexpectedly"
             );
             test.done();
@@ -246,7 +246,7 @@ exports.import_batch_integration = {
                 "import_batch didn't call send_request correct number of times before callback"
             );
             test.equals(
-                0, error_list.length,
+                null, error_list,
                 "import_batch returned errors in callback unexpectedly"
             );
             test.done();


### PR DESCRIPTION
Allows this to work with Bluebird promisification, and is probably
better anyway since returning a null error to the callback is more
typical then an empty list of errors
