### PR TITLE
stop JSON-stringification from throwing and instead return error on cb

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -40,7 +40,16 @@ var create_client = function(token, config) {
     */
     metrics.send_request = function(endpoint, data, callback) {
         callback = callback || function() {};
-        var event_data = new Buffer(JSON.stringify(data));
+
+        var event_data;
+        try {
+            event_data = new Buffer(JSON.stringify(data));
+        } catch (e) {
+            setImmediate(function(){
+                callback(e)
+            })
+            return
+        }
         var request_data = {
             'data': event_data.toString('base64'),
             'ip': 0,


### PR DESCRIPTION
Throwing when `JSON.stringify` errors seems a little unfriendly as it requires users to wrap every use of the library with a try/catch block and the library probably shouldn't throw anyway as the user has induced the error, rather the library itself doing something daft.