### PR TITLE
path prefix allows full hostnames to be added to endpoint

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -24,7 +24,6 @@ var create_client = function(token, config) {
         test: false,
         debug: false,
         verbose: false,
-        proxy: false,
         host: 'api.mixpanel.com'
     };
 
@@ -70,7 +69,7 @@ var create_client = function(token, config) {
 
         //if the host and port have been changed, and the caller has also indicated this is a proxy
         //then we want to pass through to the full http path
-        if (metrics.config.proxy) { request_options.path = "http://api.mixpanel.com"+request_options.path; }
+        if (metrics.config.path_prefix) { request_options.path = metrics.config.path_prefix+request_options.path; }
 
         http.get(request_options, function(res) {
             var data = "";

--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -13,10 +13,6 @@ var http            = require('http'),
     util            = require('util');
 
 var create_client = function(token, config) {
-    
-    console.log("create_client");
-    console.log(config);
-
     var metrics = {};
 
     if(!token) {
@@ -75,26 +71,19 @@ var create_client = function(token, config) {
 
         //if the host and port have been changed, and the caller has also indicated this is a proxy
         //then we want to pass through to the full http path
-        if (metrics.config.proxy) { request_options.path = "http://api.mixpanel.com"+request_options.path; 
-                                    console.log("request_options.path="+ request_options.path);}
+        if (metrics.config.proxy) { request_options.path = "http://api.mixpanel.com"+request_options.path; }
 
-        console.log(request_options.host+":"+request_options.port);
-        console.log("http get");
         http.get(request_options, function(res) {
-            console.log('got a response:'+res);
             var data = "";
             res.on('data', function(chunk) {
-            console.log("chunk"+chunk);
                data += chunk;
             });
 
             res.on('end', function() {
-                console.log("http end");
                 var e;
                 if (metrics.config.verbose) {
                     try {
                         var result = JSON.parse(data);
-                        console.log(result);
                         if(result.status != 1) {
                             e = new Error("Mixpanel Server Error: " + result.error);
                         }

--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -13,17 +13,23 @@ var http            = require('http'),
     util            = require('util');
 
 var create_client = function(token, config) {
+    
+    console.log("create_client");
+    console.log(config);
+
     var metrics = {};
 
     if(!token) {
         throw new Error("The Mixpanel Client needs a Mixpanel token: `init(token)`");
     }
 
+
     // Default config
     metrics.config = {
         test: false,
         debug: false,
         verbose: false,
+        proxy: false,
         host: 'api.mixpanel.com'
     };
 
@@ -67,17 +73,28 @@ var create_client = function(token, config) {
 
         request_options.path = [endpoint,"?",query].join("");
 
+        //if the host and port have been changed, and the caller has also indicated this is a proxy
+        //then we want to pass through to the full http path
+        if (metrics.config.proxy) { request_options.path = "http://api.mixpanel.com"+request_options.path; 
+                                    console.log("request_options.path="+ request_options.path);}
+
+        console.log(request_options.host+":"+request_options.port);
+        console.log("http get");
         http.get(request_options, function(res) {
+            console.log('got a response:'+res);
             var data = "";
             res.on('data', function(chunk) {
+            console.log("chunk"+chunk);
                data += chunk;
             });
 
             res.on('end', function() {
+                console.log("http end");
                 var e;
                 if (metrics.config.verbose) {
                     try {
                         var result = JSON.parse(data);
+                        console.log(result);
                         if(result.status != 1) {
                             e = new Error("Mixpanel Server Error: " + result.error);
                         }

--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -19,7 +19,6 @@ var create_client = function(token, config) {
         throw new Error("The Mixpanel Client needs a Mixpanel token: `init(token)`");
     }
 
-
     // Default config
     metrics.config = {
         test: false,

--- a/test/send_request.js
+++ b/test/send_request.js
@@ -96,5 +96,23 @@ exports.send_request = {
         test.ok(http.get.calledWithMatch(expected_http_get), "send_request didn't call http.get with correct hostname and port");
 
         test.done();
+    },
+
+    "uses path prefix": function(test) {
+        var host = 'testhost.proxyserver';
+        var prefix = 'myactualendpoint';
+        var customHostnameMixpanel = Mixpanel.init('token', { host: host, path_prefix: prefix })
+
+        var endpoint = "/track";
+
+        var expected_http_get = {
+            host: host
+        };
+
+        customHostnameMixpanel.send_request(endpoint, {});
+
+        test.ok(http.get.calledWithMatch(expected_http_get), "send_request didn't call http.get with correct arguments");
+
+        test.done();
     }
 };


### PR DESCRIPTION
Passing "path_prefix" allows anything to be prepended to the http endpoint.  This accomodates scenarios such as using a proxy host and port, which will pass through to an endpoint on a different host.  
