### PR TITLE
Reveal any data supplied, even if not JSON

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -83,7 +83,7 @@ var create_client = function(token, config) {
                         }
                     }
                     catch(ex) {
-                        e = new Error("Could not parse response from Mixpanel");
+                        e = new Error("Could not parse response from Mixpanel: " + JSON.stringify(data));
                     }
                 }
                 else {

--- a/test/send_request.js
+++ b/test/send_request.js
@@ -59,6 +59,35 @@ exports.send_request = {
         this.res.emit('end');
     },
 
+    "handles mixpanel verbose errors": function(test) {
+        test.expect(1);
+        this.mixpanel.config.verbose = true;
+        this.mixpanel.send_request("/track", { event: "test" }, function(e) {
+            test.equal(e.message, 'Mixpanel Server Error: Foobar');
+            test.done();
+        });
+
+        this.res.emit('data', JSON.stringify({
+            status: 0,
+            error: 'Foobar'
+        }));
+        this.res.emit('end');
+        this.mixpanel.config.verbose = false;
+    },
+
+    "handles mixpanel verbose errors with non-verbose response": function(test) {
+        test.expect(1);
+        this.mixpanel.config.verbose = true;
+        this.mixpanel.send_request("/track", { event: "test" }, function(e) {
+            test.equal(e.message, 'Could not parse response from Mixpanel: ""');
+            test.done();
+        });
+
+        this.res.emit('data', '');
+        this.res.emit('end');
+        this.mixpanel.config.verbose = false;
+    },
+
     "handles http.get errors": function(test) {
         test.expect(1);
         this.mixpanel.send_request("/track", { event: "test" }, function(e) {


### PR DESCRIPTION
This returns the data from Mixpanel with the error message, to give some chance of debugging rare errors from Mixpanel.