### PR TITLE
Add $ignore_alias in the allowed modifiers list

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -771,6 +771,9 @@ var create_client = function(token, config) {
             if (modifiers.hasOwnProperty("$time")) {
                 data.$time = parse_time(modifiers.$time);
             }
+            if (modifiers.$ignore_alias) {
+                data.$ignore_alias = modifiers.$ignore_alias;
+            }
         }
         return data;
     };


### PR DESCRIPTION
"$ignore_alias" set to true will prevent mixpanel to resolve aliases. 

Whitout it it is impossible to delete a user profile that redirects to another because of the redirection. For some reasons this does not seems to be documented on their side but their tech support mentioned this flag to solve my issue.  