### PR TITLE
fixed quick start guide to reflect the actual api

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ var mixpanel = Mixpanel.init('6fd9434dba686db2d1ab66b4462a3a67');
 
 // track an event with optional properties
 mixpanel.track('my event', {
-    distinct_id: 'some unique client id',
+    $distinct_id: 'some unique client id',
     as: 'many',
     properties: 'as',
     you: 'want'
@@ -83,7 +83,7 @@ mixpanel.people.clear_charges('billybob');
 mixpanel.people.delete_user('billybob');
 
 // Create an alias for an existing distinct id
-mixpanel.alias('distinct_id', 'your_alias');
+mixpanel.alias('$distinct_id', 'your_alias');
 
 // all functions that send data to mixpanel take an optional
 // callback as the last argument
@@ -98,7 +98,7 @@ var mixpanel_importer = Mixpanel.init('valid mixpanel token', {
 mixpanel_importer.track('old event', { gender: '' });
 
 mixpanel_importer.import('old event', new Date(2012, 4, 20, 12, 34, 56), {
-    distinct_id: 'billybob',
+    $distinct_id: 'billybob',
     gender: 'male'
 });
 
@@ -108,7 +108,7 @@ mixpanel_importer.import_batch([
         event: 'old event',
         properties: {
             time: new Date(2012, 4, 20, 12, 34, 56),
-            distinct_id: 'billybob',
+            $distinct_id: 'billybob',
             gender: 'male'
         }
     },
@@ -116,7 +116,7 @@ mixpanel_importer.import_batch([
         event: 'another old event',
         properties: {
             time: new Date(2012, 4, 21, 11, 33, 55),
-            distinct_id: 'billybob',
+            $distinct_id: 'billybob',
             color: 'red'
         }
     }
@@ -129,10 +129,13 @@ FAQ
 
 `mixpanel-node` is a server-side library, optimized for stateless shared usage; e.g.,
 in a web application, the same mixpanel instance is used across requests for all users.
-Rather than setting a `distinct_id` through `identify()` calls like Mixpanel client-side
-libraries (where a single Mixpanel instance is tied to a single user), this library
-requires you to pass the `distinct_id` with every tracking call. See
+Rather than setting a `distinct_id` through `identify()` calls like Mixpanel client-side libraries (where a single Mixpanel instance is tied to a single user), this library
+requires you to pass the `$distinct_id` with every tracking call. See
 https://github.com/mixpanel/mixpanel-node/issues/13.
+
+**How do I associate a user with an event I track?**
+
+Passing through a `$distinct_id` property with every single event will allow you to associate events with specific users using the Distinct Id that you have identified them with.
 
 **How do I get or set superproperties?**
 


### PR DESCRIPTION
The Distinct Id field as a property must be prefaced with `$` in order for it to be associated with a specific user (i.e. `$distinct_id`).