### PR TITLE
Track batch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 # ide files
 .idea
 
+.DS_Store

--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -41,96 +41,20 @@ var create_client = function(token, config) {
     metrics.token = token;
 
     /**
-        send_request(data)
-        ---
-        this function sends an async GET request to mixpanel
-
-        data:object                     the data to send in the request
-        callback:function(err:Error)    callback is called when the request is
-                                        finished or an error occurs
-    */
-    metrics.send_request = function(endpoint, data, callback) {
-        callback = callback || function() {};
-        var event_data = new Buffer(JSON.stringify(data));
-        var request_data = {
-            'data': event_data.toString('base64'),
-            'ip': 0,
-            'verbose': metrics.config.verbose ? 1 : 0
-        };
-
-        var request_lib = REQUEST_LIBS[metrics.config.protocol];
-        if (!request_lib) {
-            throw new Error(
-                "Mixpanel Initialization Error: Unsupported protocol " + metrics.config.protocol + ". " +
-                "Supported protocols are: " + Object.keys(REQUEST_LIBS)
-            );
-        }
-
-        if (endpoint === '/import') {
-            var key = metrics.config.key;
-            if (!key) {
-                throw new Error("The Mixpanel Client needs a Mixpanel api key when importing old events: `init(token, { key: ... })`");
-            }
-            request_data.api_key = key;
-        }
-
-        var request_options = {
-            host: metrics.config.host,
-            port: metrics.config.port,
-            headers: {}
-        };
-
-        if (metrics.config.test) { request_data.test = 1; }
-
-        var query = querystring.stringify(request_data);
-
-        request_options.path = [endpoint,"?",query].join("");
-
-        request_lib.get(request_options, function(res) {
-            var data = "";
-            res.on('data', function(chunk) {
-               data += chunk;
-            });
-
-            res.on('end', function() {
-                var e;
-                if (metrics.config.verbose) {
-                    try {
-                        var result = JSON.parse(data);
-                        if(result.status != 1) {
-                            e = new Error("Mixpanel Server Error: " + result.error);
-                        }
-                    }
-                    catch(ex) {
-                        e = new Error("Could not parse response from Mixpanel");
-                    }
-                }
-                else {
-                    e = (data !== '1') ? new Error("Mixpanel Server Error: " + data) : undefined;
-                }
-
-                callback(e);
-            });
-        }).on('error', function(e) {
-            if (metrics.config.debug) {
-                console.log("Got Error: " + e.message);
-            }
-            callback(e);
-        });
-    };
-
-    /**
+     * sends an async GET request to mixpanel
      * for batch processes data must be send in the body of a POST
      * @param {object} options
      * @param {string} options.endpoint
-     * @param {object} options.data
-     * @param {function} callback
+     * @param {object} options.data         the data to send in the request
+     * @param {string} [options.method]     e.g. `get` or `post`, defaults to `get`
+     * @param {function} callback           called on request completion or error
      */
-    metrics.send_post_request = function(options, callback) {
+    metrics.send_request = function(options, callback) {
         callback = callback || function() {};
 
-        var content = 'data=' + (new Buffer(JSON.stringify(options.data))).toString('base64'),
+        var content = (new Buffer(JSON.stringify(options.data))).toString('base64'),
             endpoint = options.endpoint,
+            method = (options.method || 'GET').toUpperCase(),
             query_params = {
                 'ip': 0,
                 'verbose': metrics.config.verbose ? 1 : 0
@@ -140,11 +64,8 @@ var create_client = function(token, config) {
             request_options = {
                 host: metrics.config.host,
                 port: metrics.config.port,
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                    'Content-Length': Buffer.byteLength(content)
-                },
-                method: 'POST'
+                headers: {},
+                method: method
             },
             request;
 
@@ -155,17 +76,29 @@ var create_client = function(token, config) {
             );
         }
 
-        // add some query params
+
+        if (method === 'POST') {
+            content = 'data=' + content;
+            request_options.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+            request_options.headers['Content-Length'] = Buffer.byteLength(content);
+        } else if (method === 'GET') {
+            // cannot ensure order with objects, but in practice this puts `data` first
+            query_params = Object.assign({ data: content }, query_params);
+        }
+
+
+        // add `key` query params
         if (key) {
             query_params.api_key = key;
         } else if (endpoint === '/import') {
             throw new Error("The Mixpanel Client needs a Mixpanel api key when importing old events: `init(token, { key: ... })`");
         }
+
         if (metrics.config.test) {
             query_params.test = 1;
         }
 
-        request_options.path = [endpoint, "?", querystring.stringify(query_params)].join("");
+        request_options.path = endpoint + "?" + querystring.stringify(query_params);
 
         request = request_lib.request(request_options, function(res) {
             var data = "";
@@ -200,7 +133,10 @@ var create_client = function(token, config) {
             }
             callback(e);
         });
-        request.write(content);
+
+        if (method === 'POST') {
+            request.write(content);
+        }
         request.end();
     };
 
@@ -224,7 +160,7 @@ var create_client = function(token, config) {
             console.log("Sending the following event to Mixpanel:\n", data);
         }
 
-        metrics.send_request(endpoint, data, callback);
+        metrics.send_request({ method: "get", endpoint: endpoint, data: data }, callback);
     };
 
     /**
@@ -289,22 +225,22 @@ var create_client = function(token, config) {
 
     /**
      * sends events in batches
-     * @param {object}      options
-     * @param {[{}]}        options.event_list              array of event objects
-     * @param {string}      options.endpoint                e.g. `/track` or `/import`
-     * @param {number}      [options.max_async_requests]    limits concurrent async requests over the network, defaults to all async
-     * @param {number}      [options.max_batch_size]        limits number of events sent to mixpanel per request
-     * @param {Function}    [callback]                      callback receives array of errors if any
+     * @param {object}   options
+     * @param {[{}]}     options.event_list                 array of event objects
+     * @param {string}   options.endpoint                   e.g. `/track` or `/import`
+     * @param {number}   [options.max_concurrent_requests]  limits concurrent async requests over the network
+     * @param {number}   [options.max_batch_size]           limits number of events sent to mixpanel per request
+     * @param {Function} [callback]                         callback receives array of errors if any
      *
      */
     var send_batch_requests = function(options, callback) {
         var event_list = options.event_list,
             endpoint = options.endpoint,
             max_batch_size = options.max_batch_size ? Math.min(MAX_BATCH_SIZE, options.max_batch_size) : MAX_BATCH_SIZE,
-            // to maintain original intention of max_batch_size; if max_batch_size is greater than 50, we assume the user is trying to set max_async_requests
-            max_async_requests = options.max_async_requests || (options.max_batch_size > MAX_BATCH_SIZE && Math.ceil(options.max_batch_size / MAX_BATCH_SIZE)),
+            // to maintain original intention of max_batch_size; if max_batch_size is greater than 50, we assume the user is trying to set max_concurrent_requests
+            max_concurrent_requests = options.max_concurrent_requests || (options.max_batch_size > MAX_BATCH_SIZE && Math.ceil(options.max_batch_size / MAX_BATCH_SIZE)),
             event_batches = chunk(event_list, max_batch_size),
-            request_batches = max_async_requests ? chunk(event_batches, max_async_requests) : [event_batches],
+            request_batches = max_concurrent_requests ? chunk(event_batches, max_concurrent_requests) : [event_batches],
             total_event_batches = event_batches.length,
             total_request_batches = request_batches.length;
 
@@ -327,7 +263,7 @@ var create_client = function(token, config) {
                 });
 
                 // must be a POST, so cannot use `metrics.send_request`
-                metrics.send_post_request({ endpoint: endpoint, data: batch }, cb);
+                metrics.send_request({ method: "post", endpoint: endpoint, data: batch }, cb);
             }
         }
 
@@ -390,17 +326,17 @@ var create_client = function(token, config) {
 
     /**
      * send a batch of events to mixpanel `track` endpoint: this should only be used if events are less than 5 days old
-     * @param {object}      options
-     * @param {Array}       options.event_list              array of event objects to track
-     * @param {object}      [options.max_async_requests]    number of concurrent http requests that can be made to mixpanel
-     * @param {object}      [options.max_batch_size]        number of events that can be sent to mixpanel per request
-     * @param {Function}    [callback]                      callback receives array of errors if any
+     * @param {object}   options
+     * @param {Array}    options.event_list                 array of event objects to track
+     * @param {object}   [options.max_concurrent_requests]  number of concurrent http requests that can be made to mixpanel
+     * @param {object}   [options.max_batch_size]           number of events that can be sent to mixpanel per request
+     * @param {Function} [callback]                         callback receives array of errors if any
      */
     metrics.track_batch = function(options, callback) {
         var batch_options = {
             event_list: options.event_list,
             endpoint: "/track",
-            max_async_requests: options.max_async_requests,
+            max_concurrent_requests: options.max_concurrent_requests,
             max_batch_size: options.max_batch_size
         };
 
@@ -490,7 +426,7 @@ var create_client = function(token, config) {
         batch_options = {
             event_list: event_list,
             endpoint: "/import",
-            max_async_requests: options.max_async_requests,
+            max_concurrent_requests: options.max_async_requests,
             max_batch_size: options.max_batch_size
         };
         send_batch_requests(batch_options, callback);
@@ -616,7 +552,7 @@ var create_client = function(token, config) {
                 console.log(data);
             }
 
-            metrics.send_request('/engage', data, callback);
+            metrics.send_request({ method: "get", endpoint: "/engage", data: data }, callback);
         },
 
         /**
@@ -695,7 +631,7 @@ var create_client = function(token, config) {
                 console.log(data);
             }
 
-            metrics.send_request('/engage', data, callback);
+            metrics.send_request({ method: "get", endpoint: "/engage", data: data }, callback);
         },
 
         /**
@@ -747,7 +683,7 @@ var create_client = function(token, config) {
                 console.log(data);
             }
 
-            metrics.send_request('/engage', data, callback);
+            metrics.send_request({ method: "get", endpoint: "/engage", data: data }, callback);
         },
 
         /**
@@ -811,7 +747,7 @@ var create_client = function(token, config) {
                 console.log(data);
             }
 
-            metrics.send_request('/engage', data, callback);
+            metrics.send_request({ method: "get", endpoint: "/engage", data: data }, callback);
         },
 
         /**
@@ -838,7 +774,7 @@ var create_client = function(token, config) {
                 console.log("Clearing this user's charges:", distinct_id);
             }
 
-            metrics.send_request('/engage', data, callback);
+            metrics.send_request({ method: "get", endpoint: "/engage", data: data }, callback);
         },
 
         /**
@@ -865,7 +801,7 @@ var create_client = function(token, config) {
                 console.log("Deleting the user from engage:", distinct_id);
             }
 
-            metrics.send_request('/engage', data, callback);
+            metrics.send_request({ method: "get", endpoint: "/engage", data: data }, callback);
         },
 
         /**
@@ -930,7 +866,7 @@ var create_client = function(token, config) {
                 console.log(data);
             }
 
-            metrics.send_request('/engage', data, callback);
+            metrics.send_request({ method: "get", endpoint: "/engage", data: data }, callback);
         },
 
         /**
@@ -976,7 +912,7 @@ var create_client = function(token, config) {
                 console.log(data);
             }
 
-            metrics.send_request('/engage', data, callback);
+            metrics.send_request({ method: "get", endpoint: "/engage", data: data }, callback);
         }
     };
 

--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -120,6 +120,91 @@ var create_client = function(token, config) {
     };
 
     /**
+     * for batch processes data must be send in the body of a POST
+     * @param {object} options
+     * @param {string} options.endpoint
+     * @param {object} options.data
+     * @param {function} callback
+     */
+    metrics.send_post_request = function(options, callback) {
+        callback = callback || function() {};
+
+        var content = 'data=' + (new Buffer(JSON.stringify(options.data))).toString('base64'),
+            endpoint = options.endpoint,
+            query_params = {
+                'ip': 0,
+                'verbose': metrics.config.verbose ? 1 : 0
+            },
+            key = metrics.config.key,
+            request_lib = REQUEST_LIBS[metrics.config.protocol],
+            request_options = {
+                host: metrics.config.host,
+                port: metrics.config.port,
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'Content-Length': Buffer.byteLength(content)
+                },
+                method: 'POST'
+            },
+            request;
+
+        if (!request_lib) {
+            throw new Error(
+                "Mixpanel Initialization Error: Unsupported protocol " + metrics.config.protocol + ". " +
+                "Supported protocols are: " + Object.keys(REQUEST_LIBS)
+            );
+        }
+
+        // add some query params
+        if (key) {
+            query_params.api_key = key;
+        } else if (endpoint === '/import') {
+            throw new Error("The Mixpanel Client needs a Mixpanel api key when importing old events: `init(token, { key: ... })`");
+        }
+        if (metrics.config.test) {
+            query_params.test = 1;
+        }
+
+        request_options.path = [endpoint, "?", querystring.stringify(query_params)].join("");
+
+        request = request_lib.request(request_options, function(res) {
+            var data = "";
+            res.on('data', function(chunk) {
+                data += chunk;
+            });
+
+            res.on('end', function() {
+                var e;
+                if (metrics.config.verbose) {
+                    try {
+                        var result = JSON.parse(data);
+                        if(result.status != 1) {
+                            e = new Error("Mixpanel Server Error: " + result.error);
+                        }
+                    }
+                    catch(ex) {
+                        e = new Error("Could not parse response from Mixpanel");
+                    }
+                }
+                else {
+                    e = (data !== '1') ? new Error("Mixpanel Server Error: " + data) : undefined;
+                }
+
+                callback(e);
+            });
+        });
+
+        request.on('error', function(e) {
+            if (metrics.config.debug) {
+                console.log("Got Error: " + e.message);
+            }
+            callback(e);
+        });
+        request.write(content);
+        request.end();
+    };
+
+    /**
      * Send an event to Mixpanel, using the specified endpoint (e.g., track/import)
      * @param {string} endpoint - API endpoint name
      * @param {string} event - event name
@@ -240,7 +325,9 @@ var create_client = function(token, config) {
                     event.properties.token = event.properties.token || metrics.token;
                     return event;
                 });
-                metrics.send_request(endpoint, batch, cb);
+
+                // must be a POST, so cannot use `metrics.send_request`
+                metrics.send_post_request({ endpoint: endpoint, data: batch }, cb);
             }
         }
 

--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -394,7 +394,7 @@ var create_client = function(token, config) {
      * @param {Array}       options.event_list              array of event objects to track
      * @param {object}      [options.max_async_requests]    number of concurrent http requests that can be made to mixpanel
      * @param {object}      [options.max_batch_size]        number of events that can be sent to mixpanel per request
-     * @param {Function}    [callback]
+     * @param {Function}    [callback]                      callback receives array of errors if any
      */
     metrics.track_batch = function(options, callback) {
         var batch_options = {

--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -179,10 +179,12 @@ var create_client = function(token, config) {
      */
     var asyncAll = function(requests, handler, callback) {
         var total = requests.length,
-            errors = [],
+            errors = null,
             results = [],
             done = function (err, result) {
                 if (err) {
+                    // errors are `null` unless there is an error, which allows for promisification
+                    errors = errors || [];
                     errors.push(err);
                 }
                 results.push(result);
@@ -194,9 +196,9 @@ var create_client = function(token, config) {
         if (total === 0) {
             callback(errors, results);
         } else {
-            requests.forEach(function(request) {
-                handler(request, done);
-            });
+            for(var i = 0, l = requests.length; i < l; i++) {
+                handler(requests[i], done);
+            }
         }
     };
 

--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -193,11 +193,12 @@ var create_client = function(token, config) {
 
     /**
      * helper to wait for all callbacks to complete; similar to `Promise.all`
+     * exposed to metrics object for unit tests
      * @param {Array} requests
      * @param {Function} handler
      * @param {Function} callback
      */
-    var asyncAll = function(requests, handler, callback) {
+    metrics.async_all = function(requests, handler, callback) {
         var total = requests.length,
             errors = null,
             results = [],
@@ -281,7 +282,7 @@ var create_client = function(token, config) {
                     }
                 };
 
-            asyncAll(request_batch, send_event_batch, cb);
+            metrics.async_all(request_batch, send_event_batch, cb);
         }
 
         // init recursive function
@@ -403,8 +404,8 @@ var create_client = function(token, config) {
             max_batch_size: the maximum number of events to be transmitted over
                             the network simultaneously. useful for capping bandwidth
                             usage.
-            max_async_requests: the maximum number of concurrent http requests that
-                                can be made to mixpanel; also useful for capping bandwidth.
+            max_concurrent_requests: the maximum number of concurrent http requests that
+                            can be made to mixpanel; also useful for capping bandwidth.
 
         N.B.: the Mixpanel API only accepts 50 events per request, so regardless
         of max_batch_size, larger lists of events will be chunked further into
@@ -425,7 +426,7 @@ var create_client = function(token, config) {
         batch_options = {
             event_list: event_list,
             endpoint: "/import",
-            max_concurrent_requests: options.max_async_requests,
+            max_concurrent_requests: options.max_concurrent_requests,
             max_batch_size: options.max_batch_size
         };
         send_batch_requests(batch_options, callback);

--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -303,25 +303,20 @@ var create_client = function(token, config) {
 
     /**
      * send a batch of events to mixpanel `track` endpoint: this should only be used if events are less than 5 days old
-     * @param {Array} event_list
-     * @param {object} options
-     * @param {object} [options.max_async_requests]   number of concurrent http requests that can be made to mixpanel
-     * @param {object} [options.max_batch_size]       number of events that can be sent to mixpanel per request
-     * @param {Function} [callback]
+     * @param {object}      options
+     * @param {Array}       options.event_list              array of event objects to track
+     * @param {object}      [options.max_async_requests]    number of concurrent http requests that can be made to mixpanel
+     * @param {object}      [options.max_batch_size]        number of events that can be sent to mixpanel per request
+     * @param {Function}    [callback]
      */
-    metrics.track_batch = function(event_list, options, callback) {
-        var batch_options;
-
-        if (typeof(options) === "function" || !options) {
-            callback = options;
-            options = {};
-        }
-        batch_options = {
-            event_list: event_list,
+    metrics.track_batch = function(options, callback) {
+        var batch_options = {
+            event_list: options.event_list,
             endpoint: "/track",
             max_async_requests: options.max_async_requests,
             max_batch_size: options.max_batch_size
         };
+
         send_batch_requests(batch_options, callback);
     };
 

--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -41,7 +41,7 @@ var create_client = function(token, config) {
     metrics.token = token;
 
     /**
-     * sends an async GET request to mixpanel
+     * sends an async GET or POST request to mixpanel
      * for batch processes data must be send in the body of a POST
      * @param {object} options
      * @param {string} options.endpoint
@@ -82,8 +82,7 @@ var create_client = function(token, config) {
             request_options.headers['Content-Type'] = 'application/x-www-form-urlencoded';
             request_options.headers['Content-Length'] = Buffer.byteLength(content);
         } else if (method === 'GET') {
-            // cannot ensure order with objects, but in practice this puts `data` first
-            query_params = Object.assign({ data: content }, query_params);
+            query_params.data = content;
         }
 
 
@@ -262,7 +261,7 @@ var create_client = function(token, config) {
                     return event;
                 });
 
-                // must be a POST, so cannot use `metrics.send_request`
+                // must be a POST
                 metrics.send_request({ method: "post", endpoint: endpoint, data: batch }, cb);
             }
         }

--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -21,6 +21,10 @@ var REQUEST_LIBS = {
 var create_client = function(token, config) {
     var metrics = {};
 
+    // mixpanel constants
+    var MAX_BATCH_SIZE = 50,
+        TRACK_AGE_LIMIT = 60 * 60 * 24 * 5;
+
     if(!token) {
         throw new Error("The Mixpanel Client needs a Mixpanel token: `init(token)`");
     }
@@ -151,6 +155,124 @@ var create_client = function(token, config) {
     };
 
     /**
+     * breaks array into equal-sized chunks, with the last chunk being the remainder
+     * @param {Array} arr
+     * @param {number} size
+     * @returns {Array}
+     */
+    var chunk = function(arr, size) {
+        var chunks = [],
+            i = 0,
+            total = arr.length;
+
+        while (i < total) {
+            chunks.push(arr.slice(i, i += size));
+        }
+        return chunks;
+    };
+
+    /**
+     * helper to wait for all callbacks to complete; similar to `Promise.all`
+     * @param {Array} requests
+     * @param {Function} handler
+     * @param {Function} callback
+     */
+    var asyncAll = function(requests, handler, callback) {
+        var total = requests.length,
+            errors = [],
+            results = [],
+            done = function (err, result) {
+                if (err) {
+                    errors.push(err);
+                }
+                results.push(result);
+                if (--total === 0) {
+                    callback(errors, results)
+                }
+            };
+
+        if (total === 0) {
+            callback(errors, results);
+        } else {
+            requests.forEach(function(request) {
+                handler(request, done);
+            });
+        }
+    };
+
+    /**
+     * sends events in batches
+     * @param {object}      options
+     * @param {[{}]}        options.event_list              array of event objects
+     * @param {string}      options.endpoint                e.g. `/track` or `/import`
+     * @param {number}      [options.max_async_requests]    limits concurrent async requests over the network, defaults to all async
+     * @param {number}      [options.max_batch_size]        limits number of events sent to mixpanel per request
+     * @param {Function}    [callback]                      callback receives array of errors if any
+     *
+     */
+    var send_batch_requests = function(options, callback) {
+        var event_list = options.event_list,
+            endpoint = options.endpoint,
+            max_batch_size = options.max_batch_size ? Math.min(MAX_BATCH_SIZE, options.max_batch_size) : MAX_BATCH_SIZE,
+            // to maintain original intention of max_batch_size; if max_batch_size is greater than 50, we assume the user is trying to set max_async_requests
+            max_async_requests = options.max_async_requests || (options.max_batch_size > MAX_BATCH_SIZE && Math.ceil(options.max_batch_size / MAX_BATCH_SIZE)),
+            event_batches = chunk(event_list, max_batch_size),
+            request_batches = max_async_requests ? chunk(event_batches, max_async_requests) : [event_batches],
+            total_event_batches = event_batches.length,
+            total_request_batches = request_batches.length;
+
+        /**
+         * sends a batch of events to mixpanel through http api
+         * @param {Array} batch
+         * @param {Function} cb
+         */
+        function send_event_batch(batch, cb) {
+            if (batch.length > 0) {
+                batch = batch.map(function (event) {
+                    var properties = event.properties;
+
+                    if (endpoint === '/import' || event.properties.time) {
+                        // usually there will be a time property, but not required for `/track` endpoint
+                        event.properties.time = ensure_timestamp(event.properties.time);
+                    }
+                    event.properties.token = event.properties.token || metrics.token;
+                    return event;
+                });
+                metrics.send_request(endpoint, batch, cb);
+            }
+        }
+
+        /**
+         * Asynchronously sends batches of requests
+         * @param {number} index
+         */
+        function send_next_request_batch(index) {
+            var request_batch = request_batches[index],
+                cb = function (errors, results) {
+                    index += 1;
+                    if (index === total_request_batches) {
+                        callback && callback(errors, results);
+                    } else {
+                        send_next_request_batch(index);
+                    }
+                };
+
+            asyncAll(request_batch, send_event_batch, cb);
+        }
+
+        // init recursive function
+        send_next_request_batch(0);
+
+        if (metrics.config.debug) {
+            console.log(
+                "Sending " + event_list.length + " events to Mixpanel in " +
+                total_event_batches + " batches of events and " +
+                total_request_batches + " batches of requests"
+            );
+        }
+    };
+
+    /**
          track(event, properties, callback)
          ---
          this function sends an event to mixpanel.
@@ -160,7 +282,6 @@ var create_client = function(token, config) {
          callback:function(err:Error)    callback is called when the request is
                                          finished or an error occurs
      */
-    var TRACK_AGE_LIMIT = 60 * 60 * 24 * 5; // 5 days in seconds
     metrics.track = function(event, properties, callback) {
         if (!properties || typeof properties === "function") {
             callback = properties;
@@ -176,6 +297,30 @@ var create_client = function(token, config) {
         }
 
         metrics.send_event_request("/track", event, properties, callback);
+    };
+
+    /**
+     * send a batch of events to mixpanel `track` endpoint: this should only be used if events are less than 5 days old
+     * @param {Array} event_list
+     * @param {object} options
+     * @param {object} [options.max_async_requests]   number of concurrent http requests that can be made to mixpanel
+     * @param {object} [options.max_batch_size]       number of events that can be sent to mixpanel per request
+     * @param {Function} [callback]
+     */
+    metrics.track_batch = function(event_list, options, callback) {
+        var batch_options;
+
+        if (typeof(options) === "function" || !options) {
+            callback = options;
+            options = {};
+        }
+        batch_options = {
+            event_list: event_list,
+            endpoint: "/track",
+            max_async_requests: options.max_async_requests,
+            max_batch_size: options.max_batch_size
+        };
+        send_batch_requests(batch_options, callback);
     };
 
     /**
@@ -239,6 +384,8 @@ var create_client = function(token, config) {
             max_batch_size: the maximum number of events to be transmitted over
                             the network simultaneously. useful for capping bandwidth
                             usage.
+            max_async_requests: the maximum number of concurrent http requests that
+                                can be made to mixpanel; also useful for capping bandwidth.
 
         N.B.: the Mixpanel API only accepts 50 events per request, so regardless
         of max_batch_size, larger lists of events will be chunked further into
@@ -250,64 +397,19 @@ var create_client = function(token, config) {
                                             finished or an error occurs
     */
     metrics.import_batch = function(event_list, options, callback) {
-        var batch_size = 50, // default: Mixpanel API permits 50 events per request
-            total_events = event_list.length,
-            max_simultaneous_events = total_events,
-            completed_events = 0,
-            event_group_idx = 0,
-            request_errors = [];
+        var batch_options;
 
-        if (typeof(options) === 'function' || !options) {
+        if (typeof(options) === "function" || !options) {
             callback = options;
             options = {};
         }
-        if (options.max_batch_size) {
-            max_simultaneous_events = options.max_batch_size;
-            if (options.max_batch_size < batch_size) {
-                batch_size = options.max_batch_size;
-            }
-        }
-
-        var send_next_batch = function() {
-            var properties,
-                event_batch = [];
-
-            // prepare batch with required props
-            for (var ei = event_group_idx; ei < total_events && ei < event_group_idx + batch_size; ei++) {
-                properties = event_list[ei].properties;
-                properties.time = ensure_timestamp(properties.time);
-                if (!properties.token) {
-                    properties.token = metrics.token;
-                }
-                event_batch.push(event_list[ei]);
-            }
-
-            if (event_batch.length > 0) {
-                metrics.send_request('/import', event_batch, function(e) {
-                    completed_events += event_batch.length;
-                    if (e) {
-                        request_errors.push(e);
-                    }
-                    if (completed_events < total_events) {
-                        send_next_batch();
-                    } else if (callback) {
-                        callback(request_errors);
-                    }
-                });
-                event_group_idx += batch_size;
-            }
+        batch_options = {
+            event_list: event_list,
+            endpoint: "/import",
+            max_async_requests: options.max_async_requests,
+            max_batch_size: options.max_batch_size
         };
-
-        if (metrics.config.debug) {
-            console.log(
-                "Sending " + event_list.length + " events to Mixpanel in " +
-                Math.ceil(total_events / batch_size) + " requests"
-            );
-        }
-
-        for (var i = 0; i < max_simultaneous_events; i += batch_size) {
-            send_next_batch();
-        }
+        send_batch_requests(batch_options, callback);
     };
 
     /**

--- a/readme.md
+++ b/readme.md
@@ -117,6 +117,25 @@ mixpanel.alias('distinct_id', 'your_alias');
 // callback as the last argument
 mixpanel.track('test', function(err) { if (err) throw err; });
 
+// track multiple events at once
+mixpanel.track_batch([
+    {
+        event: 'recent event',
+        properties: {
+            time: new Date(),
+            distinct_id: 'billybob',
+            gender: 'male'
+        }
+    },
+    {
+        event: 'another recent event',
+        properties: {
+            distinct_id: 'billybob',
+            color: 'red'
+        }
+    }
+]);
+
 // import an old event
 var mixpanel_importer = Mixpanel.init('valid mixpanel token', {
     key: 'valid api key for project'

--- a/readme.md
+++ b/readme.md
@@ -118,23 +118,25 @@ mixpanel.alias('distinct_id', 'your_alias');
 mixpanel.track('test', function(err) { if (err) throw err; });
 
 // track multiple events at once
-mixpanel.track_batch([
-    {
-        event: 'recent event',
-        properties: {
-            time: new Date(),
-            distinct_id: 'billybob',
-            gender: 'male'
+mixpanel.track_batch({
+    event_list: [
+        {
+            event: 'recent event',
+            properties: {
+                time: new Date(),
+                distinct_id: 'billybob',
+                gender: 'male'
+            }
+        },
+        {
+            event: 'another recent event',
+            properties: {
+                distinct_id: 'billybob',
+                color: 'red'
+            }
         }
-    },
-    {
-        event: 'another recent event',
-        properties: {
-            distinct_id: 'billybob',
-            color: 'red'
-        }
-    }
-]);
+    ]
+});
 
 // import an old event
 var mixpanel_importer = Mixpanel.init('valid mixpanel token', {

--- a/test/alias.js
+++ b/test/alias.js
@@ -32,7 +32,7 @@ exports.alias = {
         this.mixpanel.alias(distinct_id, alias);
 
         test.ok(
-            this.mixpanel.send_request.calledWithMatch(expected_endpoint, expected_data),
+            this.mixpanel.send_request.calledWithMatch({ endpoint: expected_endpoint, data: expected_data }),
             "alias didn't call send_request with correct arguments"
         );
 

--- a/test/async_all.js
+++ b/test/async_all.js
@@ -1,0 +1,70 @@
+var Mixpanel    = require('../lib/mixpanel-node'),
+    Sinon       = require('sinon');
+
+exports.async_all = {
+    setUp: function(next) {
+        this.mixpanel = Mixpanel.init('token');
+        next();
+    },
+
+    tearDown: function(next) {
+        next();
+    },
+
+    "calls callback with empty results if no requests": function(test) {
+        var requests = [],
+            handler_fn = Sinon.stub();
+
+        test.expect(2);
+        this.mixpanel.async_all(requests, handler_fn, function(error, results) {
+            test.equal(error, null, "error should be null");
+            test.equal(results.length, 0, "results should be empty array");
+            test.done();
+        });
+    },
+
+    "runs handler for each request and calls callback with results": function(test) {
+        var requests = [1, 2, 3],
+            handler_fn = Sinon.stub();
+
+        handler_fn
+            .onCall(0).callsArgWithAsync(1, null, 4)
+            .onCall(1).callsArgWithAsync(1, null, 5)
+            .onCall(2).callsArgWithAsync(1, null, 6);
+
+        test.expect(6);
+        this.mixpanel.async_all(requests, handler_fn, function(error, results) {
+            test.equal(handler_fn.callCount, requests.length, "handler function should be called for each request");
+            test.equal(handler_fn.getCall(0).args[0], 1, "handler called with request value");
+            test.equal(handler_fn.getCall(1).args[0], 2, "handler called with request value");
+            test.equal(handler_fn.getCall(2).args[0], 3, "handler called with request value");
+            test.equal(error, null, "error should be null");
+            test.deepEqual(results, [4, 5, 6], "results should be array of results from handler");
+            test.done();
+        });
+    },
+
+    "calls callback with errors and results from handler": function(test) {
+        var requests = [1, 2, 3],
+            handler_fn = Sinon.stub();
+
+        handler_fn
+            .onCall(0).callsArgWithAsync(1, 'error1', null)
+            .onCall(1).callsArgWithAsync(1, 'error2', null)
+            .onCall(2).callsArgWithAsync(1, null, 6);
+
+        test.expect(6);
+        this.mixpanel.async_all(requests, handler_fn, function(error, results) {
+            test.equal(handler_fn.callCount, requests.length, "handler function should be called for each request");
+            test.equal(handler_fn.getCall(0).args[0], 1, "handler called with request value");
+            test.equal(handler_fn.getCall(1).args[0], 2, "handler called with request value");
+            test.equal(handler_fn.getCall(2).args[0], 3, "handler called with request value");
+            test.deepEqual(error, ['error1', 'error2'], "errors should be returned in an array");
+            test.deepEqual(results, [null, null, 6], "results should be array of results from handler");
+            test.done();
+        });
+    }
+
+};
+
+

--- a/test/import.js
+++ b/test/import.js
@@ -284,7 +284,7 @@ exports.import_batch_integration = {
                 "import_batch didn't call send_request correct number of times before callback"
             );
             test.equals(
-                undefined, error_list,
+                null, error_list,
                 "import_batch returned errors in callback unexpectedly"
             );
             test.done();
@@ -303,7 +303,7 @@ exports.import_batch_integration = {
                 "import_batch didn't call send_request correct number of times before callback"
             );
             test.equals(
-                undefined, error_list,
+                null, error_list,
                 "import_batch returned errors in callback unexpectedly"
             );
             test.done();

--- a/test/import.js
+++ b/test/import.js
@@ -250,7 +250,7 @@ exports.import_batch_integration = {
                 "import_batch didn't call send_request correct number of times before callback"
             );
             test.equals(
-                0, error_list.length,
+                null, error_list,
                 "import_batch returned errors in callback unexpectedly"
             );
             test.done();
@@ -284,7 +284,7 @@ exports.import_batch_integration = {
                 "import_batch didn't call send_request correct number of times before callback"
             );
             test.equals(
-                0, error_list.length,
+                undefined, error_list,
                 "import_batch returned errors in callback unexpectedly"
             );
             test.done();
@@ -303,7 +303,7 @@ exports.import_batch_integration = {
                 "import_batch didn't call send_request correct number of times before callback"
             );
             test.equals(
-                0, error_list.length,
+                undefined, error_list,
                 "import_batch returned errors in callback unexpectedly"
             );
             test.done();

--- a/test/import.js
+++ b/test/import.js
@@ -39,7 +39,7 @@ exports.import = {
         this.mixpanel.import(event, time, props);
 
         test.ok(
-            this.mixpanel.send_request.calledWithMatch(expected_endpoint, expected_data),
+            this.mixpanel.send_request.calledWithMatch({ endpoint: expected_endpoint, data: expected_data }),
             "import didn't call send_request with correct arguments"
         );
 
@@ -63,7 +63,7 @@ exports.import = {
         this.mixpanel.import(event, time, props);
 
         test.ok(
-            this.mixpanel.send_request.calledWithMatch(expected_endpoint, expected_data),
+            this.mixpanel.send_request.calledWithMatch({ endpoint: expected_endpoint, data: expected_data }),
             "import didn't call send_request with correct arguments"
         );
 
@@ -87,7 +87,7 @@ exports.import = {
         this.mixpanel.import(event, time, props);
 
         test.ok(
-            this.mixpanel.send_request.calledWithMatch(expected_endpoint, expected_data),
+            this.mixpanel.send_request.calledWithMatch({ endpoint: expected_endpoint, data: expected_data }),
             "import didn't call send_request with correct arguments"
         );
 
@@ -111,7 +111,7 @@ exports.import = {
         this.mixpanel.import(event, time, props);
 
         test.ok(
-            this.mixpanel.send_request.calledWithMatch(expected_endpoint, expected_data),
+            this.mixpanel.send_request.calledWithMatch({ endpoint: expected_endpoint, data: expected_data }),
             "import didn't call send_request with correct arguments"
         );
 
@@ -141,19 +141,19 @@ exports.import_batch = {
         this.mixpanel = Mixpanel.init('token', { key: 'key' });
         this.clock = Sinon.useFakeTimers();
 
-        Sinon.stub(this.mixpanel, 'send_post_request');
+        Sinon.stub(this.mixpanel, 'send_request');
 
         next();
     },
 
     tearDown: function(next) {
-        this.mixpanel.send_post_request.restore();
+        this.mixpanel.send_request.restore();
         this.clock.restore();
 
         next();
     },
 
-    "calls send_post_request with correct endpoint and data": function(test) {
+    "calls send_request with correct endpoint, data, and method": function(test) {
         var expected_endpoint = "/import",
             event_list = [
                 {event: 'test',  properties: {key1: 'val1', time: 500 }},
@@ -169,8 +169,12 @@ exports.import_batch = {
         this.mixpanel.import_batch(event_list);
 
         test.ok(
-            this.mixpanel.send_post_request.calledWithMatch({endpoint: expected_endpoint, data: expected_data}),
-            "import_batch didn't call send_post_request with correct arguments"
+            this.mixpanel.send_request.calledWithMatch({
+                method: 'post',
+                endpoint: expected_endpoint,
+                data: expected_data
+            }),
+            "import_batch didn't call send_request with correct arguments"
         );
 
         test.done();
@@ -200,8 +204,8 @@ exports.import_batch = {
         this.mixpanel.import_batch(event_list);
 
         test.equals(
-            3, this.mixpanel.send_post_request.callCount,
-            "import_batch didn't call send_post_request correct number of times"
+            3, this.mixpanel.send_request.callCount,
+            "import_batch didn't call send_request correct number of times"
         );
 
         test.done();
@@ -251,7 +255,7 @@ exports.import_batch_integration = {
         this.mixpanel.import_batch(this.event_list, function(error_list) {
             test.equals(
                 3, http.request.callCount,
-                "import_batch didn't call send_post_request correct number of times before callback"
+                "import_batch didn't call send_request correct number of times before callback"
             );
             test.equals(
                 null, error_list,
@@ -285,7 +289,7 @@ exports.import_batch_integration = {
         this.mixpanel.import_batch(this.event_list, {max_batch_size: 100}, function(error_list) {
             test.equals(
                 3, http.request.callCount,
-                "import_batch didn't call send_post_request correct number of times before callback"
+                "import_batch didn't call send_request correct number of times before callback"
             );
             test.equals(
                 null, error_list,
@@ -304,7 +308,7 @@ exports.import_batch_integration = {
         this.mixpanel.import_batch(this.event_list, {max_batch_size: 30}, function(error_list) {
             test.equals(
                 5, http.request.callCount, // 30 + 30 + 30 + 30 + 10
-                "import_batch didn't call send_post_request correct number of times before callback"
+                "import_batch didn't call send_request correct number of times before callback"
             );
             test.equals(
                 null, error_list,
@@ -323,12 +327,12 @@ exports.import_batch_integration = {
         this.mixpanel.import_batch(this.event_list);
         test.equals(
             3, http.request.callCount,
-            "import_batch didn't call send_post_request correct number of times"
+            "import_batch didn't call send_request correct number of times"
         );
         this.mixpanel.import_batch(this.event_list, {max_batch_size: 100});
         test.equals(
             5, http.request.callCount, // 3 + 100 / 50; last request starts async
-            "import_batch didn't call send_post_request correct number of times"
+            "import_batch didn't call send_request correct number of times"
         );
         test.done();
     }

--- a/test/people.js
+++ b/test/people.js
@@ -32,12 +32,12 @@ var test_send_request_args = function(test, func, options) {
     this.mixpanel.people[func].apply(this.mixpanel.people, args);
 
     test.ok(
-        this.mixpanel.send_request.calledWithMatch(this.endpoint, expected_data),
+        this.mixpanel.send_request.calledWithMatch({ method: 'get', endpoint: this.endpoint, data: expected_data }),
         "people." + func + " didn't call send_request with correct arguments"
     );
     if (options.use_callback) {
         test.ok(
-            this.mixpanel.send_request.args[0][2] === callback,
+            this.mixpanel.send_request.args[0][1] === callback,
             "people.set didn't call send_request with a callback"
         );
     }
@@ -52,7 +52,7 @@ exports.people = {
         Sinon.stub(this.mixpanel, 'send_request');
 
         this.distinct_id = "user1";
-        this.endpoint = "engage";
+        this.endpoint = "/engage";
 
         this.test_send_request_args = test_send_request_args;
 

--- a/test/send_request.js
+++ b/test/send_request.js
@@ -11,11 +11,10 @@ exports.send_request = {
         this.http_emitter = new events.EventEmitter;
         this.http_end_spy = Sinon.spy();
         this.http_write_spy = Sinon.spy();
+        this.http_emitter.write = this.http_write_spy;
+        this.http_emitter.end = this.http_end_spy;
         this.res = new events.EventEmitter;
-        http.request.returns(Object.assign(this.http_emitter, {
-            write: this.http_write_spy,
-            end: this.http_end_spy
-        }));
+        http.request.returns(this.http_emitter);
         http.request.callsArgWith(1, this.res);
 
         next();
@@ -41,7 +40,7 @@ exports.send_request = {
                 method: 'GET',
                 host: 'api.mixpanel.com',
                 headers: {},
-                path: '/track?data=eyJldmVudCI6InRlc3QiLCJwcm9wZXJ0aWVzIjp7ImtleTEiOiJ2YWwxIiwidG9rZW4iOiJ0b2tlbiIsInRpbWUiOjEzNDY4NzY2MjF9fQ%3D%3D&ip=0&verbose=0'
+                path: '/track?ip=0&verbose=0&data=eyJldmVudCI6InRlc3QiLCJwcm9wZXJ0aWVzIjp7ImtleTEiOiJ2YWwxIiwidG9rZW4iOiJ0b2tlbiIsInRpbWUiOjEzNDY4NzY2MjF9fQ%3D%3D'
             };
 
         this.mixpanel.send_request({ method: 'get', endpoint: endpoint, data: data });
@@ -68,7 +67,7 @@ exports.send_request = {
                 method: 'GET',
                 host: 'api.mixpanel.com',
                 headers: {},
-                path: '/track?data=eyJldmVudCI6InRlc3QiLCJwcm9wZXJ0aWVzIjp7ImtleTEiOiJ2YWwxIiwidG9rZW4iOiJ0b2tlbiIsInRpbWUiOjEzNDY4NzY2MjF9fQ%3D%3D&ip=0&verbose=0'
+                path: '/track?ip=0&verbose=0&data=eyJldmVudCI6InRlc3QiLCJwcm9wZXJ0aWVzIjp7ImtleTEiOiJ2YWwxIiwidG9rZW4iOiJ0b2tlbiIsInRpbWUiOjEzNDY4NzY2MjF9fQ%3D%3D'
             };
 
         this.mixpanel.send_request({ endpoint: endpoint, data: data }); // method option not defined

--- a/test/track.js
+++ b/test/track.js
@@ -36,7 +36,7 @@ exports.track = {
         this.mixpanel.track(event, props);
 
         test.ok(
-            this.mixpanel.send_request.calledWithMatch(expected_endpoint, expected_data),
+            this.mixpanel.send_request.calledWithMatch({ endpoint: expected_endpoint, data: expected_data }),
             "track didn't call send_request with correct arguments"
         );
 
@@ -55,7 +55,7 @@ exports.track = {
         this.mixpanel.track("test");
 
         test.ok(
-            this.mixpanel.send_request.calledWithMatch(expected_endpoint, expected_data),
+            this.mixpanel.send_request.calledWithMatch({ endpoint: expected_endpoint, data: expected_data }),
             "track didn't call send_request with correct arguments"
         );
         test.done();
@@ -70,7 +70,7 @@ exports.track = {
                 }
             };
 
-        this.mixpanel.send_request.callsArgWith(2, undefined);
+        this.mixpanel.send_request.callsArgWith(1, undefined);
 
         test.expect(1);
         this.mixpanel.track("test", function(e) {
@@ -96,7 +96,7 @@ exports.track = {
         this.mixpanel.track(event, props);
 
         test.ok(
-            this.mixpanel.send_request.calledWithMatch(expected_endpoint, expected_data),
+            this.mixpanel.send_request.calledWithMatch({ endpoint: expected_endpoint, data: expected_data }),
             "track didn't call send_request with correct arguments"
         );
         test.done();
@@ -119,7 +119,7 @@ exports.track = {
         this.mixpanel.track(event, props);
 
         test.ok(
-            this.mixpanel.send_request.calledWithMatch(expected_endpoint, expected_data),
+            this.mixpanel.send_request.calledWithMatch({ endpoint: expected_endpoint, data: expected_data }),
             "track didn't call send_request with correct arguments"
         );
         test.done();
@@ -163,17 +163,17 @@ exports.track_batch = {
     setUp: function(next) {
         this.mixpanel = Mixpanel.init('token');
         this.clock = Sinon.useFakeTimers();
-        Sinon.stub(this.mixpanel, 'send_post_request');
+        Sinon.stub(this.mixpanel, 'send_request');
         next();
     },
 
     tearDown: function(next) {
-        this.mixpanel.send_post_request.restore();
+        this.mixpanel.send_request.restore();
         this.clock.restore();
         next();
     },
 
-    "calls send_post_request with correct endpoint and data2222": function(test) {
+    "calls send_request with correct endpoint, data, and method": function(test) {
         var expected_endpoint = "/track",
             event_list = [
                 {event: 'test',  properties: {key1: 'val1', time: 500 }},
@@ -189,8 +189,12 @@ exports.track_batch = {
         this.mixpanel.track_batch({event_list: event_list});
 
         test.ok(
-            this.mixpanel.send_post_request.calledWithMatch({endpoint: expected_endpoint, data: expected_data}),
-            "track_batch didn't call send_post_request with correct arguments"
+            this.mixpanel.send_request.calledWithMatch({
+                method: "post",
+                endpoint: expected_endpoint,
+                data: expected_data
+            }),
+            "track_batch didn't call send_request with correct arguments"
         );
 
         test.done();
@@ -215,8 +219,8 @@ exports.track_batch = {
         this.mixpanel.track_batch({event_list: event_list});
 
         test.equals(
-            3, this.mixpanel.send_post_request.callCount,
-            "track_batch didn't call send_post_request correct number of times"
+            3, this.mixpanel.send_request.callCount,
+            "track_batch didn't call send_request correct number of times"
         );
 
         test.done();
@@ -266,7 +270,7 @@ exports.track_batch_integration = {
         this.mixpanel.track_batch({event_list: this.event_list}, function(error_list) {
             test.equals(
                 3, http.request.callCount,
-                "track_batch didn't call send_post_request correct number of times before callback"
+                "track_batch didn't call send_request correct number of times before callback"
             );
             test.equals(
                 null, error_list,
@@ -300,7 +304,7 @@ exports.track_batch_integration = {
         this.mixpanel.track_batch({event_list: this.event_list, max_batch_size: 100}, function(error_list) {
             test.equals(
                 3, http.request.callCount,
-                "track_batch didn't call send_post_request correct number of times before callback"
+                "track_batch didn't call send_request correct number of times before callback"
             );
             test.equals(
                 null, error_list,
@@ -319,7 +323,7 @@ exports.track_batch_integration = {
         this.mixpanel.track_batch({event_list: this.event_list, max_batch_size: 30}, function(error_list) {
             test.equals(
                 5, http.request.callCount, // 30 + 30 + 30 + 30 + 10
-                "track_batch didn't call send_post_request correct number of times before callback"
+                "track_batch didn't call send_request correct number of times before callback"
             );
             test.equals(
                 null, error_list,
@@ -338,12 +342,12 @@ exports.track_batch_integration = {
         this.mixpanel.track_batch({event_list: this.event_list});
         test.equals(
             3, http.request.callCount,
-            "track_batch didn't call send_post_request correct number of times"
+            "track_batch didn't call send_request correct number of times"
         );
         this.mixpanel.track_batch({event_list: this.event_list, max_batch_size: 100});
         test.equals(
             5, http.request.callCount, // 3 + 100 / 50; last request starts async
-            "track_batch didn't call send_post_request correct number of times"
+            "track_batch didn't call send_request correct number of times"
         );
         test.done();
     }

--- a/test/track.js
+++ b/test/track.js
@@ -186,7 +186,7 @@ exports.track_batch = {
                 {event: 'test2', properties: {key2: 'val2', time: 1500, token: 'token'}}
             ];
 
-        this.mixpanel.track_batch(event_list);
+        this.mixpanel.track_batch({event_list: event_list});
 
         test.ok(
             this.mixpanel.send_request.calledWithMatch(expected_endpoint, expected_data),
@@ -202,7 +202,7 @@ exports.track_batch = {
             {event: 'test',  properties: {key2: 'val2', time: 1000}},
             {event: 'test2', properties: {key2: 'val2'            }}
         ];
-        test.doesNotThrow(this.mixpanel.track_batch.bind(this, event_list));
+        test.doesNotThrow(this.mixpanel.track_batch.bind(this, {event_list: event_list}));
         test.done();
     },
 
@@ -212,7 +212,7 @@ exports.track_batch = {
             event_list.push({event: 'test',  properties: {key1: 'val1', time: 500 + ei }});
         }
 
-        this.mixpanel.track_batch(event_list);
+        this.mixpanel.track_batch({event_list: event_list});
 
         test.equals(
             3, this.mixpanel.send_request.callCount,
@@ -259,7 +259,7 @@ exports.track_batch_integration = {
 
     "calls provided callback after all requests finish": function(test) {
         test.expect(2);
-        this.mixpanel.track_batch(this.event_list, function(error_list) {
+        this.mixpanel.track_batch({event_list: this.event_list}, function(error_list) {
             test.equals(
                 3, http.get.callCount,
                 "track_batch didn't call send_request correct number of times before callback"
@@ -278,7 +278,7 @@ exports.track_batch_integration = {
 
     "passes error list to callback": function(test) {
         test.expect(1);
-        this.mixpanel.track_batch(this.event_list, function(error_list) {
+        this.mixpanel.track_batch({event_list: this.event_list}, function(error_list) {
             test.equals(
                 3, error_list.length,
                 "track_batch didn't return errors in callback"
@@ -293,7 +293,7 @@ exports.track_batch_integration = {
 
     "calls provided callback when options are passed": function(test) {
         test.expect(2);
-        this.mixpanel.track_batch(this.event_list, {max_batch_size: 100}, function(error_list) {
+        this.mixpanel.track_batch({event_list: this.event_list, max_batch_size: 100}, function(error_list) {
             test.equals(
                 3, http.get.callCount,
                 "track_batch didn't call send_request correct number of times before callback"
@@ -312,7 +312,7 @@ exports.track_batch_integration = {
 
     "sends more requests when max_batch_size < 50": function(test) {
         test.expect(2);
-        this.mixpanel.track_batch(this.event_list, {max_batch_size: 30}, function(error_list) {
+        this.mixpanel.track_batch({event_list: this.event_list, max_batch_size: 30}, function(error_list) {
             test.equals(
                 5, http.get.callCount, // 30 + 30 + 30 + 30 + 10
                 "track_batch didn't call send_request correct number of times before callback"
@@ -331,12 +331,12 @@ exports.track_batch_integration = {
 
     "behaves well without a callback": function(test) {
         test.expect(2);
-        this.mixpanel.track_batch(this.event_list);
+        this.mixpanel.track_batch({event_list: this.event_list});
         test.equals(
             3, http.get.callCount,
             "track_batch didn't call send_request correct number of times"
         );
-        this.mixpanel.track_batch(this.event_list, {max_batch_size: 100});
+        this.mixpanel.track_batch({event_list: this.event_list, max_batch_size: 100});
         test.equals(
             5, http.get.callCount, // 3 + 100 / 50; last request starts async
             "track_batch didn't call send_request correct number of times"

--- a/test/track.js
+++ b/test/track.js
@@ -265,7 +265,7 @@ exports.track_batch_integration = {
                 "track_batch didn't call send_request correct number of times before callback"
             );
             test.equals(
-                0, error_list.length,
+                null, error_list,
                 "track_batch returned errors in callback unexpectedly"
             );
             test.done();
@@ -299,7 +299,7 @@ exports.track_batch_integration = {
                 "track_batch didn't call send_request correct number of times before callback"
             );
             test.equals(
-                0, error_list.length,
+                null, error_list,
                 "track_batch returned errors in callback unexpectedly"
             );
             test.done();
@@ -318,7 +318,7 @@ exports.track_batch_integration = {
                 "track_batch didn't call send_request correct number of times before callback"
             );
             test.equals(
-                0, error_list.length,
+                null, error_list,
                 "track_batch returned errors in callback unexpectedly"
             );
             test.done();

--- a/test/track.js
+++ b/test/track.js
@@ -1,5 +1,7 @@
 var Mixpanel    = require('../lib/mixpanel-node'),
     Sinon       = require('sinon'),
+    http        = require('http'),
+    events      = require('events'),
     mock_now_time = new Date(2016, 1, 1).getTime();
 
 exports.track = {
@@ -156,3 +158,190 @@ exports.track = {
         test.done();
     }
 };
+
+exports.track_batch = {
+    setUp: function(next) {
+        this.mixpanel = Mixpanel.init('token');
+        this.clock = Sinon.useFakeTimers();
+        Sinon.stub(this.mixpanel, 'send_request');
+        next();
+    },
+
+    tearDown: function(next) {
+        this.mixpanel.send_request.restore();
+        this.clock.restore();
+        next();
+    },
+
+    "calls send_request with correct endpoint and data2222": function(test) {
+        var expected_endpoint = "/track",
+            event_list = [
+                {event: 'test',  properties: {key1: 'val1', time: 500 }},
+                {event: 'test',  properties: {key2: 'val2', time: 1000}},
+                {event: 'test2', properties: {key2: 'val2', time: 1500}}
+            ],
+            expected_data = [
+                {event: 'test',  properties: {key1: 'val1', time: 500,  token: 'token'}},
+                {event: 'test',  properties: {key2: 'val2', time: 1000, token: 'token'}},
+                {event: 'test2', properties: {key2: 'val2', time: 1500, token: 'token'}}
+            ];
+
+        this.mixpanel.track_batch(event_list);
+
+        test.ok(
+            this.mixpanel.send_request.calledWithMatch(expected_endpoint, expected_data),
+            "track_batch didn't call send_request with correct arguments"
+        );
+
+        test.done();
+    },
+
+    "does not require the time argument for every event": function(test) {
+        var event_list = [
+            {event: 'test',  properties: {key1: 'val1', time: 500 }},
+            {event: 'test',  properties: {key2: 'val2', time: 1000}},
+            {event: 'test2', properties: {key2: 'val2'            }}
+        ];
+        test.doesNotThrow(this.mixpanel.track_batch.bind(this, event_list));
+        test.done();
+    },
+
+    "batches 50 events at a time": function(test) {
+        var event_list = [];
+        for (var ei = 0; ei < 130; ei++) { // 3 batches: 50 + 50 + 30
+            event_list.push({event: 'test',  properties: {key1: 'val1', time: 500 + ei }});
+        }
+
+        this.mixpanel.track_batch(event_list);
+
+        test.equals(
+            3, this.mixpanel.send_request.callCount,
+            "track_batch didn't call send_request correct number of times"
+        );
+
+        test.done();
+    }
+};
+
+exports.track_batch_integration = {
+    setUp: function(next) {
+        this.mixpanel = Mixpanel.init('token', { key: 'key' });
+        this.clock = Sinon.useFakeTimers();
+
+        Sinon.stub(http, 'get');
+
+        this.http_emitter = new events.EventEmitter();
+
+        // stub sequence of http responses
+        this.res = [];
+        for (var ri = 0; ri < 5; ri++) {
+            this.res.push(new events.EventEmitter());
+            http.get
+                .onCall(ri)
+                .callsArgWith(1, this.res[ri])
+                .returns(this.http_emitter);
+        }
+
+        this.event_list = [];
+        for (var ei = 0; ei < 130; ei++) { // 3 batches: 50 + 50 + 30
+            this.event_list.push({event: 'test',  properties: {key1: 'val1', time: 500 + ei }});
+        }
+
+        next();
+    },
+
+    tearDown: function(next) {
+        http.get.restore();
+        this.clock.restore();
+
+        next();
+    },
+
+    "calls provided callback after all requests finish": function(test) {
+        test.expect(2);
+        this.mixpanel.track_batch(this.event_list, function(error_list) {
+            test.equals(
+                3, http.get.callCount,
+                "track_batch didn't call send_request correct number of times before callback"
+            );
+            test.equals(
+                0, error_list.length,
+                "track_batch returned errors in callback unexpectedly"
+            );
+            test.done();
+        });
+        for (var ri = 0; ri < 3; ri++) {
+            this.res[ri].emit('data', '1');
+            this.res[ri].emit('end');
+        }
+    },
+
+    "passes error list to callback": function(test) {
+        test.expect(1);
+        this.mixpanel.track_batch(this.event_list, function(error_list) {
+            test.equals(
+                3, error_list.length,
+                "track_batch didn't return errors in callback"
+            );
+            test.done();
+        });
+        for (var ri = 0; ri < 3; ri++) {
+            this.res[ri].emit('data', '0');
+            this.res[ri].emit('end');
+        }
+    },
+
+    "calls provided callback when options are passed": function(test) {
+        test.expect(2);
+        this.mixpanel.track_batch(this.event_list, {max_batch_size: 100}, function(error_list) {
+            test.equals(
+                3, http.get.callCount,
+                "track_batch didn't call send_request correct number of times before callback"
+            );
+            test.equals(
+                0, error_list.length,
+                "track_batch returned errors in callback unexpectedly"
+            );
+            test.done();
+        });
+        for (var ri = 0; ri < 3; ri++) {
+            this.res[ri].emit('data', '1');
+            this.res[ri].emit('end');
+        }
+    },
+
+    "sends more requests when max_batch_size < 50": function(test) {
+        test.expect(2);
+        this.mixpanel.track_batch(this.event_list, {max_batch_size: 30}, function(error_list) {
+            test.equals(
+                5, http.get.callCount, // 30 + 30 + 30 + 30 + 10
+                "track_batch didn't call send_request correct number of times before callback"
+            );
+            test.equals(
+                0, error_list.length,
+                "track_batch returned errors in callback unexpectedly"
+            );
+            test.done();
+        });
+        for (var ri = 0; ri < 5; ri++) {
+            this.res[ri].emit('data', '1');
+            this.res[ri].emit('end');
+        }
+    },
+
+    "behaves well without a callback": function(test) {
+        test.expect(2);
+        this.mixpanel.track_batch(this.event_list);
+        test.equals(
+            3, http.get.callCount,
+            "track_batch didn't call send_request correct number of times"
+        );
+        this.mixpanel.track_batch(this.event_list, {max_batch_size: 100});
+        test.equals(
+            5, http.get.callCount, // 3 + 100 / 50; last request starts async
+            "track_batch didn't call send_request correct number of times"
+        );
+        test.done();
+    }
+};
+


### PR DESCRIPTION
This PR adds support for batch tracking with the method `metrics.track_batch`. This method takes `options` and optional `callback` arguments. The benefit of `track_batch` over `import_batch` is that events reported with `track_batch` will appear in mixpanel's "live view". The limitation of `track_batch` is that the events must be less than 5 days old.

Both `track_batch` and `import_batch` call the `send_batch_requests` function.

One breaking change is that the import_batch method calls the callback with `null` rather than an empty array if there are no errors. This change is useful as it follows standard node callback format, which makes it friendly to methods like `bluebird.promisify`.

Also fixes #114 

`metrics.send_request` has been refactored to handle both GET and POST requests. In this refactor the arguments have been reduced to `options` and `callback`. This is a breaking change to the `send_request` method, which is exposed, but is not documented in the readme. I am assuming that `send_request` is exported only so that it could be easily tested, so users should not need to update their code.