### PR TITLE
Auto-detect HTTP_PROXY and HTTPS_PROXY environment variables

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -23,7 +23,6 @@ var create_proxy_agent = function() {
     var proxyPath = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
 
     if (proxyPath) {
-        console.log('proxy', proxyPath);
         return new HttpsProxyAgent(proxyPath);
     }
 
@@ -90,7 +89,6 @@ var create_client = function(token, config) {
         };
 
         if (proxyAgent) {
-            console.log('setting agent');
             request_options.agent = proxyAgent;
         }
         
@@ -101,8 +99,6 @@ var create_client = function(token, config) {
         request_options.path = [endpoint,"?",query].join("");
 
         request_lib.get(request_options, function(res) {
-            console.log('here');
-
             var data = "";
             res.on('data', function(chunk) {
                data += chunk;
@@ -128,7 +124,6 @@ var create_client = function(token, config) {
                 callback(e);
             });
         }).on('error', function(e) {
-            console.log('get failed', e);
             if (metrics.config.debug) {
                 console.log("Got Error: " + e.message);
             }

--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -20,7 +20,7 @@ var REQUEST_LIBS = {
 };
 
 var create_proxy_agent = function() {
-    var proxyPath = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
+    var proxyPath = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
 
     if (proxyPath) {
         return new HttpsProxyAgent(proxyPath);

--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -7,19 +7,32 @@
     Released under the MIT license.
 */
 
-var http        = require('http'),
-    https       = require('https'),
-    querystring = require('querystring'),
-    Buffer      = require('buffer').Buffer,
-    util        = require('util');
+var http            = require('http'),
+    https           = require('https'),
+    querystring     = require('querystring'),
+    Buffer          = require('buffer').Buffer,
+    util            = require('util'),
+    HttpsProxyAgent = require('https-proxy-agent');
 
 var REQUEST_LIBS = {
     http: http,
     https: https
 };
 
+var create_proxy_agent = function() {
+    var proxyPath = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
+
+    if (proxyPath) {
+        console.log('proxy', proxyPath);
+        return new HttpsProxyAgent(proxyPath);
+    }
+
+    return;
+}
+
 var create_client = function(token, config) {
     var metrics = {};
+    var proxyAgent = create_proxy_agent();
 
     if(!token) {
         throw new Error("The Mixpanel Client needs a Mixpanel token: `init(token)`");
@@ -76,6 +89,11 @@ var create_client = function(token, config) {
             headers: {}
         };
 
+        if (proxyAgent) {
+            console.log('setting agent');
+            request_options.agent = proxyAgent;
+        }
+        
         if (metrics.config.test) { request_data.test = 1; }
 
         var query = querystring.stringify(request_data);
@@ -83,6 +101,8 @@ var create_client = function(token, config) {
         request_options.path = [endpoint,"?",query].join("");
 
         request_lib.get(request_options, function(res) {
+            console.log('here');
+
             var data = "";
             res.on('data', function(chunk) {
                data += chunk;
@@ -108,6 +128,7 @@ var create_client = function(token, config) {
                 callback(e);
             });
         }).on('error', function(e) {
+            console.log('get failed', e);
             if (metrics.config.debug) {
                 console.log("Got Error: " + e.message);
             }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
   },
   "devDependencies": {
     "nodeunit": "^0.9.1",
+    "proxyquire": "^1.7.11",
     "sinon": "^1.14.1"
+  },
+  "dependencies": {
+    "https-proxy-agent": "^1.0.0"
   }
 }

--- a/test/send_request.js
+++ b/test/send_request.js
@@ -114,6 +114,7 @@ exports.send_request = {
 
     "uses HTTP_PROXY if set": function(test) {
         HttpsProxyAgent.reset(); // Mixpanel is instantiated in setup, need to reset callcount
+        delete process.env.HTTPS_PROXY;
         process.env.HTTP_PROXY = 'this.aint.real.http';
         delete process.env.HTTPS_PROXY;
 


### PR DESCRIPTION
This lib won't be able to run from behind a proxy. This PR adds detection of HTTP_PROXY and HTTPS_PROXY environment variables and if found, will create a proxy agent for the request.

This is a common pattern in Node (see the `request` lib) and other languages (I'm aware of at least Go, Python, Ruby, and R). Detecting environment variables simplifies the config that users would have to write to support multiple environments (e.g., local environments are unlikely to have HTTP proxying, while a production environment would).