### PR TITLE
Use HTTPS by default

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -44,7 +44,7 @@ var create_client = function(token, config) {
         debug: false,
         verbose: false,
         host: 'api.mixpanel.com',
-        protocol: 'http'
+        protocol: 'https'
     };
 
     metrics.token = token;

--- a/test/config.js
+++ b/test/config.js
@@ -12,7 +12,7 @@ exports.config = {
             debug: false,
             verbose: false,
             host: 'api.mixpanel.com',
-            protocol: 'http'
+            protocol: 'https'
         }, "default config is incorrect");
         test.done();
     },


### PR DESCRIPTION
This makes the library use HTTPS (instead of HTTP) as a transport by default.