### PR TITLE
Allow request to automatically geolocate based on client IP

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -44,7 +44,10 @@ var create_client = function(token, config) {
         debug: false,
         verbose: false,
         host: 'api.mixpanel.com',
-        protocol: 'https'
+        protocol: 'https',
+        // set this to true to automatically geolocate based on the client's ip.
+        // e.g., when running under electron
+        geolocate: false
     };
 
     metrics.token = token;
@@ -65,7 +68,7 @@ var create_client = function(token, config) {
             endpoint = options.endpoint,
             method = (options.method || 'GET').toUpperCase(),
             query_params = {
-                'ip': 0,
+                'ip': metrics.config.geolocate ? 1 : 0,
                 'verbose': metrics.config.verbose ? 1 : 0
             },
             key = metrics.config.key,

--- a/test/config.js
+++ b/test/config.js
@@ -12,7 +12,8 @@ exports.config = {
             debug: false,
             verbose: false,
             host: 'api.mixpanel.com',
-            protocol: 'https'
+            protocol: 'https',
+            geolocate: false
         }, "default config is incorrect");
         test.done();
     },

--- a/test/send_request.js
+++ b/test/send_request.js
@@ -120,6 +120,16 @@ exports.send_request = {
         test.done();
     },
 
+    "includes configured request data": function(test) {
+      this.mixpanel.set_config({ geolocate: true });
+
+      this.mixpanel.send_request({ method: "get", endpoint: "/track", event: "test", data: {} });
+
+      test.ok(http.request.calledWithMatch({ path: Sinon.match('ip=1') }), "send_request didn't call http.get with correct request data");
+
+      test.done();
+    },
+
     "handles mixpanel errors": function(test) {
         test.expect(1);
         this.mixpanel.send_request({ endpoint: "/track", data: { event: "test" } }, function(e) {


### PR DESCRIPTION
This work is based on PR #42, but has been squashed and pulled into the future.

There was some contention around the naming of the previous configuration option, I've opted for `geolocate` here in an effort to express the intent.  When I set this option `true`, any message that is sent to mixpanel will be geolocated based on the request's source ip.

The use cases for this are effectively any sort of node code that is distributed to users - whether that be in electron/nw.js or even something as simple as a cli package installed with `npm i -g`.

