### PR TITLE
Add avoid_mutation config flag

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -43,6 +43,7 @@ var create_client = function(token, config) {
         test: false,
         debug: false,
         verbose: false,
+        avoidMutation: false,
         host: 'api.mixpanel.com',
         protocol: 'https'
     };
@@ -294,6 +295,10 @@ var create_client = function(token, config) {
             properties = {};
         }
 
+        if (metrics.config.avoidMutation) {
+            properties = clone_object(properties);
+        }
+
         // time is optional for `track` but must be less than 5 days old if set
         if (properties.time) {
             properties.time = ensure_timestamp(properties.time);
@@ -319,6 +324,11 @@ var create_client = function(token, config) {
             callback = options;
             options = {};
         }
+
+        if (metrics.config.avoidMutation) {
+            event_list = clone_array(event_list);
+        }
+
         var batch_options = {
             event_list: event_list,
             endpoint: "/track",
@@ -353,6 +363,10 @@ var create_client = function(token, config) {
         if (!properties || typeof properties === "function") {
             callback = properties;
             properties = {};
+        }
+
+        if (metrics.config.avoidMutation) {
+            properties = clone_object(properties);
         }
 
         properties.time = ensure_timestamp(time);
@@ -409,6 +423,11 @@ var create_client = function(token, config) {
             callback = options;
             options = {};
         }
+
+        if (metrics.config.avoidMutation) {
+            event_list = clone_array(event_list);
+        }
+
         batch_options = {
             event_list: event_list,
             endpoint: "/import",
@@ -454,6 +473,10 @@ var create_client = function(token, config) {
         set_once: function(distinct_id, prop, to, modifiers, callback) {
             var $set = {};
 
+            if (metrics.config.avoidMutation) {
+                prop = clone_object(prop);
+            }
+
             if (typeof(prop) === 'object') {
                 if (typeof(to) === 'object') {
                     callback = modifiers;
@@ -491,6 +514,10 @@ var create_client = function(token, config) {
         */
         set: function(distinct_id, prop, to, modifiers, callback) {
             var $set = {};
+
+            if (metrics.config.avoidMutation) {
+                prop = clone_object(prop);
+            }
 
             if (typeof(prop) === 'object') {
                 if (typeof(to) === 'object') {
@@ -687,6 +714,10 @@ var create_client = function(token, config) {
                 mixpanel.people.track_charge('bob', 19, { '$time': new Date('feb 1 2012') });
         */
         track_charge: function(distinct_id, amount, properties, modifiers, callback) {
+            if (metrics.config.avoidMutation) {
+                properties = clone_object(properties);
+            }
+
             if (typeof(properties) === 'function' || !properties) {
                 callback = properties || function() {};
                 properties = {};
@@ -918,6 +949,30 @@ var create_client = function(token, config) {
             }
         }
         return data;
+    };
+
+    /**
+     * helper to clone array|collection or return value as is if not an array
+     * @param {Array} arr Array to clone
+     * @return {Array} Cloned array or passed non-array value
+     */
+    var clone_array = function(arr) {
+        if (Array.isArray(arr)) {
+            return arr.map(clone_object);
+        }
+        return arr;
+    };
+
+    /**
+     * helper to clone object or return value as is if not an object
+     * @param {Object} obj Object to clone
+     * @return {Object} Cloned object or passed non-object value
+     */
+    var clone_object = function(obj) {
+        if (obj === Object(obj)) {
+            return Object.assign({}, obj);
+        }
+        return obj;
     };
 
     /**

--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -43,7 +43,7 @@ var create_client = function(token, config) {
         test: false,
         debug: false,
         verbose: false,
-        avoidMutation: false,
+        avoid_mutation: false,
         host: 'api.mixpanel.com',
         protocol: 'https'
     };
@@ -295,7 +295,7 @@ var create_client = function(token, config) {
             properties = {};
         }
 
-        if (metrics.config.avoidMutation) {
+        if (metrics.config.avoid_mutation) {
             properties = clone_object(properties);
         }
 
@@ -325,7 +325,7 @@ var create_client = function(token, config) {
             options = {};
         }
 
-        if (metrics.config.avoidMutation) {
+        if (metrics.config.avoid_mutation) {
             event_list = clone_array(event_list);
         }
 
@@ -365,7 +365,7 @@ var create_client = function(token, config) {
             properties = {};
         }
 
-        if (metrics.config.avoidMutation) {
+        if (metrics.config.avoid_mutation) {
             properties = clone_object(properties);
         }
 
@@ -424,7 +424,7 @@ var create_client = function(token, config) {
             options = {};
         }
 
-        if (metrics.config.avoidMutation) {
+        if (metrics.config.avoid_mutation) {
             event_list = clone_array(event_list);
         }
 
@@ -473,7 +473,7 @@ var create_client = function(token, config) {
         set_once: function(distinct_id, prop, to, modifiers, callback) {
             var $set = {};
 
-            if (metrics.config.avoidMutation) {
+            if (metrics.config.avoid_mutation) {
                 prop = clone_object(prop);
             }
 
@@ -515,7 +515,7 @@ var create_client = function(token, config) {
         set: function(distinct_id, prop, to, modifiers, callback) {
             var $set = {};
 
-            if (metrics.config.avoidMutation) {
+            if (metrics.config.avoid_mutation) {
                 prop = clone_object(prop);
             }
 
@@ -714,7 +714,7 @@ var create_client = function(token, config) {
                 mixpanel.people.track_charge('bob', 19, { '$time': new Date('feb 1 2012') });
         */
         track_charge: function(distinct_id, amount, properties, modifiers, callback) {
-            if (metrics.config.avoidMutation) {
+            if (metrics.config.avoid_mutation) {
                 properties = clone_object(properties);
             }
 

--- a/test/config.js
+++ b/test/config.js
@@ -11,6 +11,7 @@ exports.config = {
             test: false,
             debug: false,
             verbose: false,
+            avoidMutation: false,
             host: 'api.mixpanel.com',
             protocol: 'https'
         }, "default config is incorrect");

--- a/test/config.js
+++ b/test/config.js
@@ -11,7 +11,7 @@ exports.config = {
             test: false,
             debug: false,
             verbose: false,
-            avoidMutation: false,
+            avoid_mutation: false,
             host: 'api.mixpanel.com',
             protocol: 'https'
         }, "default config is incorrect");


### PR DESCRIPTION
See https://github.com/mixpanel/mixpanel-node/issues/119. 
After adding `avoidMutation` flag set to `true`, `mixpanel-node` library will not mutate data that you are passing into its methods. 
Also it's not a breaking change, so there will be no impact for users of the `mixpanel-node` library after updating the version.