### PR TITLE
Add Typescript type declaration file

### DIFF
--- a/lib/mixpanel-node.d.ts
+++ b/lib/mixpanel-node.d.ts
@@ -63,92 +63,32 @@ declare namespace mixpanel {
 
   interface People {
     set(distinctId: string, properties: PropertyDict, callback?: Callback): undefined;
-    set(
-      distinctId: string,
-      properties: PropertyDict,
-      modifiers?: Modifiers,
-      callback?: Callback,
-    ): undefined;
+    set(distinctId: string, properties: PropertyDict, modifiers?: Modifiers, callback?: Callback): undefined;
     set(distinctId: string, propertyName: string, value: string | number, modifiers: Modifiers): undefined;
     set(distinctId: string, propertyName: string, value: string | number, callback?: Callback): undefined;
-    set(
-      distinctId: string,
-      propertyName: string,
-      value: string | number,
-      modifiers: Modifiers,
-      callback: Callback,
-    ): undefined;
+    set(distinctId: string, propertyName: string, value: string | number, modifiers: Modifiers, callback: Callback): undefined;
 
     set_once(distinctId: string, propertyName: string, value: string, callback?: Callback): undefined;
-    set_once(
-      distinctId: string,
-      propertyName: string,
-      value: string,
-      modifiers: Modifiers,
-      callback?: Callback,
-    ): undefined;
+    set_once( distinctId: string, propertyName: string, value: string, modifiers: Modifiers, callback?: Callback): undefined;
     set_once(distinctId: string, properties: PropertyDict, callback?: Callback): undefined;
-    set_once(
-      distinctId: string,
-      properties: PropertyDict,
-      modifiers?: Modifiers,
-      callback?: Callback,
-    ): undefined;
+    set_once(distinctId: string, properties: PropertyDict, modifiers?: Modifiers, callback?: Callback): undefined;
 
-    increment(
-      distinctId: string,
-      propertyName: string,
-      modifiers?: Modifiers,
-      callback?: Callback,
-    ): undefined;
-    increment(
-      distinctId: string,
-      propertyName: string,
-      incrementBy: number,
-      modifiers: Modifiers,
-      callback?: Callback,
-    ): undefined;
+    increment(distinctId: string, propertyName: string, modifiers?: Modifiers, callback?: Callback): undefined;
+    increment(distinctId: string, propertyName: string, incrementBy: number, modifiers: Modifiers, callback?: Callback): undefined;
     increment(distinctId: string, propertyName: string, incrementBy: number, callback?: Callback): undefined;
-    increment(
-      distinctId: string,
-      properties: NumberMap,
-      modifiers: Modifiers,
-      callback?: Callback,
-    ): undefined;
+    increment(distinctId: string, properties: NumberMap, modifiers: Modifiers, callback?: Callback): undefined;
     increment(distinctId: string, properties: NumberMap, callback?: Callback): undefined;
 
-    append(
-      distinctId: string,
-      propertyName: string,
-      value: any,
-      modifiers: Modifiers,
-      callback?: Callback,
-    ): undefined;
+    append(distinctId: string, propertyName: string, value: any, modifiers: Modifiers, callback?: Callback): undefined;
     append(distinctId: string, propertyName: string, value: any, callback?: Callback): undefined;
     append(distinctId: string, properties: PropertyDict, callback?: Callback): undefined;
-    append(
-      distinctId: string,
-      properties: PropertyDict,
-      modifiers: Modifiers,
-      callback?: Callback,
-    ): undefined;
+    append(distinctId: string, properties: PropertyDict, modifiers: Modifiers, callback?: Callback): undefined;
 
     union(distinctId: string, data: UnionData, modifiers?: Modifiers, callback?: Callback): undefined;
     union(distinctId: string, data: UnionData, callback: Callback): undefined;
 
-    track_charge(
-      distinctId: string,
-      amount: number | string,
-      properties?: PropertyDict,
-      callback?: Callback,
-    ): undefined;
-    track_charge(
-      distinctId: string,
-      amount: number | string,
-      properties: PropertyDict,
-      modifiers?: Modifiers,
-      callback?: Callback,
-    ): undefined;
+    track_charge(distinctId: string, amount: number | string, properties?: PropertyDict, callback?: Callback): undefined;
+    track_charge(distinctId: string, amount: number | string, properties: PropertyDict, modifiers?: Modifiers, callback?: Callback): undefined;
 
     clear_charges(distinctId: string, modifiers?: Modifiers, callback?: Callback): undefined;
     clear_charges(distinctId: string, callback: Callback): undefined;

--- a/lib/mixpanel-node.d.ts
+++ b/lib/mixpanel-node.d.ts
@@ -1,161 +1,159 @@
-declare module 'mixpanel' {
-  const mixpanel: mixpanel.Mixpanel;
+declare const mixpanel: mixpanel.Mixpanel;
 
-  namespace mixpanel {
-    export type DistinctId = string;
+declare namespace mixpanel {
+  export type DistinctId = string;
 
-    export type ErrorCallback = (err: Error|undefined) => any;
-    export type ErrorsCallback = (errors: [Error]|undefined) => any;
-    
-    type Scalar = string|number|boolean;
+  export type ErrorCallback = (err: Error|undefined) => any;
+  export type ErrorsCallback = (errors: [Error]|undefined) => any;
 
-    export interface PropertyMap {
-      [key: string]: any;
-    }
+  type Scalar = string|number|boolean;
 
-    export interface NumberMap {
-      [key: string]: number;
-    }
-
-    export interface Event {
-      event: string;
-      properties: PropertyMap;
-    }
-    export interface Modifiers {
-      $ip?: string;
-      $ignore_time?: boolean;
-      $time?: string;
-      $ignore_alias?: boolean;
-    }
-
-    export interface BatchOptions {
-      max_concurrent_requests?: number;
-      max_batch_size?: number;
-    }
-
-    export interface UnionData {
-      [key: string]: Scalar|Scalar[];
-    }
-
-    interface Mixpanel {
-      init(mixpanelToken: string, config?: PropertyMap): Mixpanel;
-
-      track(eventName: string, callback?: ErrorCallback): undefined;
-      track(eventName: string, properties: Object, callback?: ErrorCallback): undefined;
-
-      track_batch(events: Event[], options?: BatchOptions, callback?: ErrorsCallback): undefined;
-      track_batch(events: Event[], callback: ErrorsCallback): undefined;
-      track_batch(eventNames: string[], options?: BatchOptions, callback?: ErrorsCallback): undefined;
-      track_batch(eventNames: string[], callback?: ErrorsCallback): undefined;
-
-      import(eventName: string, time: Date|number, properties?: Object, callback?: ErrorCallback): undefined;
-      import(eventName: string, time: Date|number, callback: ErrorCallback): undefined;
-
-      import_batch(eventNames: string[], options?: BatchOptions, callback?: ErrorsCallback): undefined;
-      import_batch(eventNames: string[], callback?: ErrorsCallback): undefined;
-      import_batch(events: Event[], callback?: ErrorsCallback): undefined;
-
-      alias(distinctId: DistinctId, alias: string, callback?: ErrorCallback): undefined;
-
-      people: People;
-    }
-
-    interface People {
-      set(distinctId: DistinctId, properties: PropertyMap, callback?: ErrorCallback): undefined;
-      set(
-        distinctId: DistinctId,
-        properties: PropertyMap,
-        modifiers?: Modifiers,
-        callback?: ErrorCallback,
-      ): undefined;
-      set(distinctId: DistinctId, propertyName: string, value: string|number, modifiers: Modifiers): undefined;
-      set(distinctId: DistinctId, propertyName: string, value: string|number, callback?: ErrorCallback): undefined;
-      set(
-        distinctId: DistinctId,
-        propertyName: string,
-        value: string|number,
-        modifiers: Modifiers,
-        callback: ErrorCallback,
-      ): undefined;
-
-      set_once(distinctId: DistinctId, propertyName: string, value: string, callback?: ErrorCallback): undefined;
-      set_once(
-        distinctId: DistinctId,
-        propertyName: string,
-        value: string,
-        modifiers: Modifiers,
-        callback?: ErrorCallback,
-      ): undefined;
-      set_once(distinctId: DistinctId, properties: PropertyMap, callback?: ErrorCallback): undefined;
-      set_once(
-        distinctId: DistinctId,
-        properties: PropertyMap,
-        modifiers?: Modifiers,
-        callback?: ErrorCallback,
-      ): undefined;
-
-      increment(
-        distinctId: DistinctId,
-        propertyName: string,
-        modifiers?: Modifiers,
-        callback?: ErrorCallback,
-      ): undefined;
-      increment(
-        distinctId: DistinctId,
-        propertyName: string,
-        incrementBy: number,
-        modifiers: Modifiers,
-        callback?: ErrorCallback,
-      ): undefined;
-      increment(distinctId: DistinctId, propertyName: string, incrementBy: number, callback?: ErrorCallback): undefined;
-      increment(
-        distinctId: DistinctId,
-        properties: NumberMap,
-        modifiers: Modifiers,
-        callback?: ErrorCallback,
-      ): undefined;
-      increment(distinctId: DistinctId, properties: NumberMap, callback?: ErrorCallback): undefined;
-
-      append(
-        distinctId: DistinctId,
-        propertyName: string,
-        value: any,
-        modifiers: Modifiers,
-        callback?: ErrorCallback,
-      ): undefined;
-      append(distinctId: DistinctId, propertyName: string, value: any, callback?: ErrorCallback): undefined;
-      append(distinctId: DistinctId, properties: PropertyMap, callback?: ErrorCallback): undefined;
-      append(
-        distinctId: DistinctId,
-        properties: PropertyMap,
-        modifiers: Modifiers,
-        callback?: ErrorCallback,
-      ): undefined;
-
-      union(distinctId: DistinctId, data: UnionData, modifiers?: Modifiers, callback?: ErrorCallback): undefined;
-      union(distinctId: DistinctId, data: UnionData, callback: ErrorCallback): undefined;
-
-      track_charge(
-        distinctId: DistinctId,
-        amount: number|string,
-        properties?: PropertyMap,
-        callback?: ErrorCallback,
-      ): undefined;
-      track_charge(
-        distinctId: DistinctId,
-        amount: number|string,
-        properties: PropertyMap,
-        modifiers?: Modifiers,
-        callback?: ErrorCallback,
-      ): undefined;
-
-      clear_charges(distinctId: DistinctId, modifiers?: Modifiers, callback?: ErrorCallback): undefined;
-      clear_charges(distinctId: DistinctId, callback: ErrorCallback): undefined;
-
-      delete_user(distinctId: DistinctId, modifiers?: Modifiers, callback?: ErrorCallback): undefined;
-      delete_user(distinctId: DistinctId, callback: ErrorCallback): undefined;
-    }
+  export interface PropertyMap {
+    [key: string]: any;
   }
 
-  export = mixpanel;
+  export interface NumberMap {
+    [key: string]: number;
+  }
+
+  export interface Event {
+    event: string;
+    properties: PropertyMap;
+  }
+  export interface Modifiers {
+    $ip?: string;
+    $ignore_time?: boolean;
+    $time?: string;
+    $ignore_alias?: boolean;
+  }
+
+  export interface BatchOptions {
+    max_concurrent_requests?: number;
+    max_batch_size?: number;
+  }
+
+  export interface UnionData {
+    [key: string]: Scalar|Scalar[];
+  }
+
+  interface Mixpanel {
+    init(mixpanelToken: string, config?: PropertyMap): Mixpanel;
+
+    track(eventName: string, callback?: ErrorCallback): undefined;
+    track(eventName: string, properties: Object, callback?: ErrorCallback): undefined;
+
+    track_batch(events: Event[], options?: BatchOptions, callback?: ErrorsCallback): undefined;
+    track_batch(events: Event[], callback: ErrorsCallback): undefined;
+    track_batch(eventNames: string[], options?: BatchOptions, callback?: ErrorsCallback): undefined;
+    track_batch(eventNames: string[], callback?: ErrorsCallback): undefined;
+
+    import(eventName: string, time: Date|number, properties?: Object, callback?: ErrorCallback): undefined;
+    import(eventName: string, time: Date|number, callback: ErrorCallback): undefined;
+
+    import_batch(eventNames: string[], options?: BatchOptions, callback?: ErrorsCallback): undefined;
+    import_batch(eventNames: string[], callback?: ErrorsCallback): undefined;
+    import_batch(events: Event[], callback?: ErrorsCallback): undefined;
+
+    alias(distinctId: DistinctId, alias: string, callback?: ErrorCallback): undefined;
+
+    people: People;
+  }
+
+  interface People {
+    set(distinctId: DistinctId, properties: PropertyMap, callback?: ErrorCallback): undefined;
+    set(
+      distinctId: DistinctId,
+      properties: PropertyMap,
+      modifiers?: Modifiers,
+      callback?: ErrorCallback,
+    ): undefined;
+    set(distinctId: DistinctId, propertyName: string, value: string|number, modifiers: Modifiers): undefined;
+    set(distinctId: DistinctId, propertyName: string, value: string|number, callback?: ErrorCallback): undefined;
+    set(
+      distinctId: DistinctId,
+      propertyName: string,
+      value: string|number,
+      modifiers: Modifiers,
+      callback: ErrorCallback,
+    ): undefined;
+
+    set_once(distinctId: DistinctId, propertyName: string, value: string, callback?: ErrorCallback): undefined;
+    set_once(
+      distinctId: DistinctId,
+      propertyName: string,
+      value: string,
+      modifiers: Modifiers,
+      callback?: ErrorCallback,
+    ): undefined;
+    set_once(distinctId: DistinctId, properties: PropertyMap, callback?: ErrorCallback): undefined;
+    set_once(
+      distinctId: DistinctId,
+      properties: PropertyMap,
+      modifiers?: Modifiers,
+      callback?: ErrorCallback,
+    ): undefined;
+
+    increment(
+      distinctId: DistinctId,
+      propertyName: string,
+      modifiers?: Modifiers,
+      callback?: ErrorCallback,
+    ): undefined;
+    increment(
+      distinctId: DistinctId,
+      propertyName: string,
+      incrementBy: number,
+      modifiers: Modifiers,
+      callback?: ErrorCallback,
+    ): undefined;
+    increment(distinctId: DistinctId, propertyName: string, incrementBy: number, callback?: ErrorCallback): undefined;
+    increment(
+      distinctId: DistinctId,
+      properties: NumberMap,
+      modifiers: Modifiers,
+      callback?: ErrorCallback,
+    ): undefined;
+    increment(distinctId: DistinctId, properties: NumberMap, callback?: ErrorCallback): undefined;
+
+    append(
+      distinctId: DistinctId,
+      propertyName: string,
+      value: any,
+      modifiers: Modifiers,
+      callback?: ErrorCallback,
+    ): undefined;
+    append(distinctId: DistinctId, propertyName: string, value: any, callback?: ErrorCallback): undefined;
+    append(distinctId: DistinctId, properties: PropertyMap, callback?: ErrorCallback): undefined;
+    append(
+      distinctId: DistinctId,
+      properties: PropertyMap,
+      modifiers: Modifiers,
+      callback?: ErrorCallback,
+    ): undefined;
+
+    union(distinctId: DistinctId, data: UnionData, modifiers?: Modifiers, callback?: ErrorCallback): undefined;
+    union(distinctId: DistinctId, data: UnionData, callback: ErrorCallback): undefined;
+
+    track_charge(
+      distinctId: DistinctId,
+      amount: number|string,
+      properties?: PropertyMap,
+      callback?: ErrorCallback,
+    ): undefined;
+    track_charge(
+      distinctId: DistinctId,
+      amount: number|string,
+      properties: PropertyMap,
+      modifiers?: Modifiers,
+      callback?: ErrorCallback,
+    ): undefined;
+
+    clear_charges(distinctId: DistinctId, modifiers?: Modifiers, callback?: ErrorCallback): undefined;
+    clear_charges(distinctId: DistinctId, callback: ErrorCallback): undefined;
+
+    delete_user(distinctId: DistinctId, modifiers?: Modifiers, callback?: ErrorCallback): undefined;
+    delete_user(distinctId: DistinctId, callback: ErrorCallback): undefined;
+  }
 }
+
+export = mixpanel;

--- a/lib/mixpanel-node.d.ts
+++ b/lib/mixpanel-node.d.ts
@@ -3,10 +3,10 @@ declare const mixpanel: mixpanel.Mixpanel;
 declare namespace mixpanel {
   export type DistinctId = string;
 
-  export type ErrorCallback = (err: Error|undefined) => any;
-  export type ErrorsCallback = (errors: [Error]|undefined) => any;
+  export type ErrorCallback = (err: Error | undefined) => any;
+  export type ErrorsCallback = (errors: [Error] | undefined) => any;
 
-  type Scalar = string|number|boolean;
+  type Scalar = string | number | boolean;
 
   export interface PropertyMap {
     [key: string]: any;
@@ -33,7 +33,7 @@ declare namespace mixpanel {
   }
 
   export interface UnionData {
-    [key: string]: Scalar|Scalar[];
+    [key: string]: Scalar | Scalar[];
   }
 
   interface Mixpanel {
@@ -47,8 +47,8 @@ declare namespace mixpanel {
     track_batch(eventNames: string[], options?: BatchOptions, callback?: ErrorsCallback): undefined;
     track_batch(eventNames: string[], callback?: ErrorsCallback): undefined;
 
-    import(eventName: string, time: Date|number, properties?: Object, callback?: ErrorCallback): undefined;
-    import(eventName: string, time: Date|number, callback: ErrorCallback): undefined;
+    import(eventName: string, time: Date | number, properties?: Object, callback?: ErrorCallback): undefined;
+    import(eventName: string, time: Date | number, callback: ErrorCallback): undefined;
 
     import_batch(eventNames: string[], options?: BatchOptions, callback?: ErrorsCallback): undefined;
     import_batch(eventNames: string[], callback?: ErrorsCallback): undefined;
@@ -67,12 +67,12 @@ declare namespace mixpanel {
       modifiers?: Modifiers,
       callback?: ErrorCallback,
     ): undefined;
-    set(distinctId: DistinctId, propertyName: string, value: string|number, modifiers: Modifiers): undefined;
-    set(distinctId: DistinctId, propertyName: string, value: string|number, callback?: ErrorCallback): undefined;
+    set(distinctId: DistinctId, propertyName: string, value: string | number, modifiers: Modifiers): undefined;
+    set(distinctId: DistinctId, propertyName: string, value: string | number, callback?: ErrorCallback): undefined;
     set(
       distinctId: DistinctId,
       propertyName: string,
-      value: string|number,
+      value: string | number,
       modifiers: Modifiers,
       callback: ErrorCallback,
     ): undefined;
@@ -136,13 +136,13 @@ declare namespace mixpanel {
 
     track_charge(
       distinctId: DistinctId,
-      amount: number|string,
+      amount: number | string,
       properties?: PropertyMap,
       callback?: ErrorCallback,
     ): undefined;
     track_charge(
       distinctId: DistinctId,
-      amount: number|string,
+      amount: number | string,
       properties: PropertyMap,
       modifiers?: Modifiers,
       callback?: ErrorCallback,

--- a/lib/mixpanel-node.d.ts
+++ b/lib/mixpanel-node.d.ts
@@ -1,8 +1,6 @@
 declare const mixpanel: mixpanel.Mixpanel;
 
 declare namespace mixpanel {
-  export type DistinctId = string;
-
   export type ErrorCallback = (err: Error | undefined) => any;
   export type ErrorsCallback = (errors: [Error] | undefined) => any;
 
@@ -54,105 +52,105 @@ declare namespace mixpanel {
     import_batch(eventNames: string[], callback?: ErrorsCallback): undefined;
     import_batch(events: Event[], callback?: ErrorsCallback): undefined;
 
-    alias(distinctId: DistinctId, alias: string, callback?: ErrorCallback): undefined;
+    alias(distinctId: string, alias: string, callback?: ErrorCallback): undefined;
 
     people: People;
   }
 
   interface People {
-    set(distinctId: DistinctId, properties: PropertyMap, callback?: ErrorCallback): undefined;
+    set(distinctId: string, properties: PropertyMap, callback?: ErrorCallback): undefined;
     set(
-      distinctId: DistinctId,
+      distinctId: string,
       properties: PropertyMap,
       modifiers?: Modifiers,
       callback?: ErrorCallback,
     ): undefined;
-    set(distinctId: DistinctId, propertyName: string, value: string | number, modifiers: Modifiers): undefined;
-    set(distinctId: DistinctId, propertyName: string, value: string | number, callback?: ErrorCallback): undefined;
+    set(distinctId: string, propertyName: string, value: string | number, modifiers: Modifiers): undefined;
+    set(distinctId: string, propertyName: string, value: string | number, callback?: ErrorCallback): undefined;
     set(
-      distinctId: DistinctId,
+      distinctId: string,
       propertyName: string,
       value: string | number,
       modifiers: Modifiers,
       callback: ErrorCallback,
     ): undefined;
 
-    set_once(distinctId: DistinctId, propertyName: string, value: string, callback?: ErrorCallback): undefined;
+    set_once(distinctId: string, propertyName: string, value: string, callback?: ErrorCallback): undefined;
     set_once(
-      distinctId: DistinctId,
+      distinctId: string,
       propertyName: string,
       value: string,
       modifiers: Modifiers,
       callback?: ErrorCallback,
     ): undefined;
-    set_once(distinctId: DistinctId, properties: PropertyMap, callback?: ErrorCallback): undefined;
+    set_once(distinctId: string, properties: PropertyMap, callback?: ErrorCallback): undefined;
     set_once(
-      distinctId: DistinctId,
+      distinctId: string,
       properties: PropertyMap,
       modifiers?: Modifiers,
       callback?: ErrorCallback,
     ): undefined;
 
     increment(
-      distinctId: DistinctId,
+      distinctId: string,
       propertyName: string,
       modifiers?: Modifiers,
       callback?: ErrorCallback,
     ): undefined;
     increment(
-      distinctId: DistinctId,
+      distinctId: string,
       propertyName: string,
       incrementBy: number,
       modifiers: Modifiers,
       callback?: ErrorCallback,
     ): undefined;
-    increment(distinctId: DistinctId, propertyName: string, incrementBy: number, callback?: ErrorCallback): undefined;
+    increment(distinctId: string, propertyName: string, incrementBy: number, callback?: ErrorCallback): undefined;
     increment(
-      distinctId: DistinctId,
+      distinctId: string,
       properties: NumberMap,
       modifiers: Modifiers,
       callback?: ErrorCallback,
     ): undefined;
-    increment(distinctId: DistinctId, properties: NumberMap, callback?: ErrorCallback): undefined;
+    increment(distinctId: string, properties: NumberMap, callback?: ErrorCallback): undefined;
 
     append(
-      distinctId: DistinctId,
+      distinctId: string,
       propertyName: string,
       value: any,
       modifiers: Modifiers,
       callback?: ErrorCallback,
     ): undefined;
-    append(distinctId: DistinctId, propertyName: string, value: any, callback?: ErrorCallback): undefined;
-    append(distinctId: DistinctId, properties: PropertyMap, callback?: ErrorCallback): undefined;
+    append(distinctId: string, propertyName: string, value: any, callback?: ErrorCallback): undefined;
+    append(distinctId: string, properties: PropertyMap, callback?: ErrorCallback): undefined;
     append(
-      distinctId: DistinctId,
+      distinctId: string,
       properties: PropertyMap,
       modifiers: Modifiers,
       callback?: ErrorCallback,
     ): undefined;
 
-    union(distinctId: DistinctId, data: UnionData, modifiers?: Modifiers, callback?: ErrorCallback): undefined;
-    union(distinctId: DistinctId, data: UnionData, callback: ErrorCallback): undefined;
+    union(distinctId: string, data: UnionData, modifiers?: Modifiers, callback?: ErrorCallback): undefined;
+    union(distinctId: string, data: UnionData, callback: ErrorCallback): undefined;
 
     track_charge(
-      distinctId: DistinctId,
+      distinctId: string,
       amount: number | string,
       properties?: PropertyMap,
       callback?: ErrorCallback,
     ): undefined;
     track_charge(
-      distinctId: DistinctId,
+      distinctId: string,
       amount: number | string,
       properties: PropertyMap,
       modifiers?: Modifiers,
       callback?: ErrorCallback,
     ): undefined;
 
-    clear_charges(distinctId: DistinctId, modifiers?: Modifiers, callback?: ErrorCallback): undefined;
-    clear_charges(distinctId: DistinctId, callback: ErrorCallback): undefined;
+    clear_charges(distinctId: string, modifiers?: Modifiers, callback?: ErrorCallback): undefined;
+    clear_charges(distinctId: string, callback: ErrorCallback): undefined;
 
-    delete_user(distinctId: DistinctId, modifiers?: Modifiers, callback?: ErrorCallback): undefined;
-    delete_user(distinctId: DistinctId, callback: ErrorCallback): undefined;
+    delete_user(distinctId: string, modifiers?: Modifiers, callback?: ErrorCallback): undefined;
+    delete_user(distinctId: string, callback: ErrorCallback): undefined;
   }
 }
 

--- a/lib/mixpanel-node.d.ts
+++ b/lib/mixpanel-node.d.ts
@@ -41,60 +41,60 @@ declare namespace mixpanel {
   interface Mixpanel {
     init(mixpanelToken: string, config?: InitConfig): Mixpanel;
 
-    track(eventName: string, callback?: Callback): undefined;
-    track(eventName: string, properties: PropertyDict, callback?: Callback): undefined;
+    track(eventName: string, callback?: Callback): void;
+    track(eventName: string, properties: PropertyDict, callback?: Callback): void;
 
-    track_batch(events: Event[], options?: BatchOptions, callback?: BatchCallback): undefined;
-    track_batch(events: Event[], callback: BatchCallback): undefined;
-    track_batch(eventNames: string[], options?: BatchOptions, callback?: BatchCallback): undefined;
-    track_batch(eventNames: string[], callback?: BatchCallback): undefined;
+    track_batch(events: Event[], options?: BatchOptions, callback?: BatchCallback): void;
+    track_batch(events: Event[], callback: BatchCallback): void;
+    track_batch(eventNames: string[], options?: BatchOptions, callback?: BatchCallback): void;
+    track_batch(eventNames: string[], callback?: BatchCallback): void;
 
-    import(eventName: string, time: Date | number, properties?: PropertyDict, callback?: Callback): undefined;
-    import(eventName: string, time: Date | number, callback: Callback): undefined;
+    import(eventName: string, time: Date | number, properties?: PropertyDict, callback?: Callback): void;
+    import(eventName: string, time: Date | number, callback: Callback): void;
 
-    import_batch(eventNames: string[], options?: BatchOptions, callback?: BatchCallback): undefined;
-    import_batch(eventNames: string[], callback?: BatchCallback): undefined;
-    import_batch(events: Event[], callback?: BatchCallback): undefined;
+    import_batch(eventNames: string[], options?: BatchOptions, callback?: BatchCallback): void;
+    import_batch(eventNames: string[], callback?: BatchCallback): void;
+    import_batch(events: Event[], callback?: BatchCallback): void;
 
-    alias(distinctId: string, alias: string, callback?: Callback): undefined;
+    alias(distinctId: string, alias: string, callback?: Callback): void;
 
     people: People;
   }
 
   interface People {
-    set(distinctId: string, properties: PropertyDict, callback?: Callback): undefined;
-    set(distinctId: string, properties: PropertyDict, modifiers?: Modifiers, callback?: Callback): undefined;
-    set(distinctId: string, propertyName: string, value: string | number, modifiers: Modifiers): undefined;
-    set(distinctId: string, propertyName: string, value: string | number, callback?: Callback): undefined;
-    set(distinctId: string, propertyName: string, value: string | number, modifiers: Modifiers, callback: Callback): undefined;
+    set(distinctId: string, properties: PropertyDict, callback?: Callback): void;
+    set(distinctId: string, properties: PropertyDict, modifiers?: Modifiers, callback?: Callback): void;
+    set(distinctId: string, propertyName: string, value: string | number, modifiers: Modifiers): void;
+    set(distinctId: string, propertyName: string, value: string | number, callback?: Callback): void;
+    set(distinctId: string, propertyName: string, value: string | number, modifiers: Modifiers, callback: Callback): void;
 
-    set_once(distinctId: string, propertyName: string, value: string, callback?: Callback): undefined;
-    set_once( distinctId: string, propertyName: string, value: string, modifiers: Modifiers, callback?: Callback): undefined;
-    set_once(distinctId: string, properties: PropertyDict, callback?: Callback): undefined;
-    set_once(distinctId: string, properties: PropertyDict, modifiers?: Modifiers, callback?: Callback): undefined;
+    set_once(distinctId: string, propertyName: string, value: string, callback?: Callback): void;
+    set_once( distinctId: string, propertyName: string, value: string, modifiers: Modifiers, callback?: Callback): void;
+    set_once(distinctId: string, properties: PropertyDict, callback?: Callback): void;
+    set_once(distinctId: string, properties: PropertyDict, modifiers?: Modifiers, callback?: Callback): void;
 
-    increment(distinctId: string, propertyName: string, modifiers?: Modifiers, callback?: Callback): undefined;
-    increment(distinctId: string, propertyName: string, incrementBy: number, modifiers: Modifiers, callback?: Callback): undefined;
-    increment(distinctId: string, propertyName: string, incrementBy: number, callback?: Callback): undefined;
-    increment(distinctId: string, properties: NumberMap, modifiers: Modifiers, callback?: Callback): undefined;
-    increment(distinctId: string, properties: NumberMap, callback?: Callback): undefined;
+    increment(distinctId: string, propertyName: string, modifiers?: Modifiers, callback?: Callback): void;
+    increment(distinctId: string, propertyName: string, incrementBy: number, modifiers: Modifiers, callback?: Callback): void;
+    increment(distinctId: string, propertyName: string, incrementBy: number, callback?: Callback): void;
+    increment(distinctId: string, properties: NumberMap, modifiers: Modifiers, callback?: Callback): void;
+    increment(distinctId: string, properties: NumberMap, callback?: Callback): void;
 
-    append(distinctId: string, propertyName: string, value: any, modifiers: Modifiers, callback?: Callback): undefined;
-    append(distinctId: string, propertyName: string, value: any, callback?: Callback): undefined;
-    append(distinctId: string, properties: PropertyDict, callback?: Callback): undefined;
-    append(distinctId: string, properties: PropertyDict, modifiers: Modifiers, callback?: Callback): undefined;
+    append(distinctId: string, propertyName: string, value: any, modifiers: Modifiers, callback?: Callback): void;
+    append(distinctId: string, propertyName: string, value: any, callback?: Callback): void;
+    append(distinctId: string, properties: PropertyDict, callback?: Callback): void;
+    append(distinctId: string, properties: PropertyDict, modifiers: Modifiers, callback?: Callback): void;
 
-    union(distinctId: string, data: UnionData, modifiers?: Modifiers, callback?: Callback): undefined;
-    union(distinctId: string, data: UnionData, callback: Callback): undefined;
+    union(distinctId: string, data: UnionData, modifiers?: Modifiers, callback?: Callback): void;
+    union(distinctId: string, data: UnionData, callback: Callback): void;
 
-    track_charge(distinctId: string, amount: number | string, properties?: PropertyDict, callback?: Callback): undefined;
-    track_charge(distinctId: string, amount: number | string, properties: PropertyDict, modifiers?: Modifiers, callback?: Callback): undefined;
+    track_charge(distinctId: string, amount: number | string, properties?: PropertyDict, callback?: Callback): void;
+    track_charge(distinctId: string, amount: number | string, properties: PropertyDict, modifiers?: Modifiers, callback?: Callback): void;
 
-    clear_charges(distinctId: string, modifiers?: Modifiers, callback?: Callback): undefined;
-    clear_charges(distinctId: string, callback: Callback): undefined;
+    clear_charges(distinctId: string, modifiers?: Modifiers, callback?: Callback): void;
+    clear_charges(distinctId: string, callback: Callback): void;
 
-    delete_user(distinctId: string, modifiers?: Modifiers, callback?: Callback): undefined;
-    delete_user(distinctId: string, callback: Callback): undefined;
+    delete_user(distinctId: string, modifiers?: Modifiers, callback?: Callback): void;
+    delete_user(distinctId: string, callback: Callback): void;
   }
 }
 

--- a/lib/mixpanel-node.d.ts
+++ b/lib/mixpanel-node.d.ts
@@ -38,14 +38,14 @@ declare namespace mixpanel {
     init(mixpanelToken: string, config?: PropertyDict): Mixpanel;
 
     track(eventName: string, callback?: ErrorCallback): undefined;
-    track(eventName: string, properties: Object, callback?: ErrorCallback): undefined;
+    track(eventName: string, properties: PropertyDict, callback?: ErrorCallback): undefined;
 
     track_batch(events: Event[], options?: BatchOptions, callback?: ErrorsCallback): undefined;
     track_batch(events: Event[], callback: ErrorsCallback): undefined;
     track_batch(eventNames: string[], options?: BatchOptions, callback?: ErrorsCallback): undefined;
     track_batch(eventNames: string[], callback?: ErrorsCallback): undefined;
 
-    import(eventName: string, time: Date | number, properties?: Object, callback?: ErrorCallback): undefined;
+    import(eventName: string, time: Date | number, properties?: PropertyDict, callback?: ErrorCallback): undefined;
     import(eventName: string, time: Date | number, callback: ErrorCallback): undefined;
 
     import_batch(eventNames: string[], options?: BatchOptions, callback?: ErrorsCallback): undefined;

--- a/lib/mixpanel-node.d.ts
+++ b/lib/mixpanel-node.d.ts
@@ -6,6 +6,10 @@ declare namespace mixpanel {
 
   type Scalar = string | number | boolean;
 
+  export interface InitConfig {
+    [key: string]: any;
+  }
+
   export interface PropertyDict {
     [key: string]: any;
   }
@@ -35,7 +39,7 @@ declare namespace mixpanel {
   }
 
   interface Mixpanel {
-    init(mixpanelToken: string, config?: PropertyDict): Mixpanel;
+    init(mixpanelToken: string, config?: InitConfig): Mixpanel;
 
     track(eventName: string, callback?: ErrorCallback): undefined;
     track(eventName: string, properties: PropertyDict, callback?: ErrorCallback): undefined;

--- a/lib/mixpanel-node.d.ts
+++ b/lib/mixpanel-node.d.ts
@@ -1,0 +1,161 @@
+declare module 'mixpanel' {
+  const mixpanel: mixpanel.Mixpanel;
+
+  namespace mixpanel {
+    export type DistinctId = string;
+
+    export type ErrorCallback = (err: Error|undefined) => any;
+    export type ErrorsCallback = (errors: [Error]|undefined) => any;
+    
+    type Scalar = string|number|boolean;
+
+    export interface PropertyMap {
+      [key: string]: any;
+    }
+
+    export interface NumberMap {
+      [key: string]: number;
+    }
+
+    export interface Event {
+      event: string;
+      properties: PropertyMap;
+    }
+    export interface Modifiers {
+      $ip?: string;
+      $ignore_time?: boolean;
+      $time?: string;
+      $ignore_alias?: boolean;
+    }
+
+    export interface BatchOptions {
+      max_concurrent_requests?: number;
+      max_batch_size?: number;
+    }
+
+    export interface UnionData {
+      [key: string]: Scalar|Scalar[];
+    }
+
+    interface Mixpanel {
+      init(mixpanelToken: string, config?: PropertyMap): Mixpanel;
+
+      track(eventName: string, callback?: ErrorCallback): undefined;
+      track(eventName: string, properties: Object, callback?: ErrorCallback): undefined;
+
+      track_batch(events: Event[], options?: BatchOptions, callback?: ErrorsCallback): undefined;
+      track_batch(events: Event[], callback: ErrorsCallback): undefined;
+      track_batch(eventNames: string[], options?: BatchOptions, callback?: ErrorsCallback): undefined;
+      track_batch(eventNames: string[], callback?: ErrorsCallback): undefined;
+
+      import(eventName: string, time: Date|number, properties?: Object, callback?: ErrorCallback): undefined;
+      import(eventName: string, time: Date|number, callback: ErrorCallback): undefined;
+
+      import_batch(eventNames: string[], options?: BatchOptions, callback?: ErrorsCallback): undefined;
+      import_batch(eventNames: string[], callback?: ErrorsCallback): undefined;
+      import_batch(events: Event[], callback?: ErrorsCallback): undefined;
+
+      alias(distinctId: DistinctId, alias: string, callback?: ErrorCallback): undefined;
+
+      people: People;
+    }
+
+    interface People {
+      set(distinctId: DistinctId, properties: PropertyMap, callback?: ErrorCallback): undefined;
+      set(
+        distinctId: DistinctId,
+        properties: PropertyMap,
+        modifiers?: Modifiers,
+        callback?: ErrorCallback,
+      ): undefined;
+      set(distinctId: DistinctId, propertyName: string, value: string|number, modifiers: Modifiers): undefined;
+      set(distinctId: DistinctId, propertyName: string, value: string|number, callback?: ErrorCallback): undefined;
+      set(
+        distinctId: DistinctId,
+        propertyName: string,
+        value: string|number,
+        modifiers: Modifiers,
+        callback: ErrorCallback,
+      ): undefined;
+
+      set_once(distinctId: DistinctId, propertyName: string, value: string, callback?: ErrorCallback): undefined;
+      set_once(
+        distinctId: DistinctId,
+        propertyName: string,
+        value: string,
+        modifiers: Modifiers,
+        callback?: ErrorCallback,
+      ): undefined;
+      set_once(distinctId: DistinctId, properties: PropertyMap, callback?: ErrorCallback): undefined;
+      set_once(
+        distinctId: DistinctId,
+        properties: PropertyMap,
+        modifiers?: Modifiers,
+        callback?: ErrorCallback,
+      ): undefined;
+
+      increment(
+        distinctId: DistinctId,
+        propertyName: string,
+        modifiers?: Modifiers,
+        callback?: ErrorCallback,
+      ): undefined;
+      increment(
+        distinctId: DistinctId,
+        propertyName: string,
+        incrementBy: number,
+        modifiers: Modifiers,
+        callback?: ErrorCallback,
+      ): undefined;
+      increment(distinctId: DistinctId, propertyName: string, incrementBy: number, callback?: ErrorCallback): undefined;
+      increment(
+        distinctId: DistinctId,
+        properties: NumberMap,
+        modifiers: Modifiers,
+        callback?: ErrorCallback,
+      ): undefined;
+      increment(distinctId: DistinctId, properties: NumberMap, callback?: ErrorCallback): undefined;
+
+      append(
+        distinctId: DistinctId,
+        propertyName: string,
+        value: any,
+        modifiers: Modifiers,
+        callback?: ErrorCallback,
+      ): undefined;
+      append(distinctId: DistinctId, propertyName: string, value: any, callback?: ErrorCallback): undefined;
+      append(distinctId: DistinctId, properties: PropertyMap, callback?: ErrorCallback): undefined;
+      append(
+        distinctId: DistinctId,
+        properties: PropertyMap,
+        modifiers: Modifiers,
+        callback?: ErrorCallback,
+      ): undefined;
+
+      union(distinctId: DistinctId, data: UnionData, modifiers?: Modifiers, callback?: ErrorCallback): undefined;
+      union(distinctId: DistinctId, data: UnionData, callback: ErrorCallback): undefined;
+
+      track_charge(
+        distinctId: DistinctId,
+        amount: number|string,
+        properties?: PropertyMap,
+        callback?: ErrorCallback,
+      ): undefined;
+      track_charge(
+        distinctId: DistinctId,
+        amount: number|string,
+        properties: PropertyMap,
+        modifiers?: Modifiers,
+        callback?: ErrorCallback,
+      ): undefined;
+
+      clear_charges(distinctId: DistinctId, modifiers?: Modifiers, callback?: ErrorCallback): undefined;
+      clear_charges(distinctId: DistinctId, callback: ErrorCallback): undefined;
+
+      delete_user(distinctId: DistinctId, modifiers?: Modifiers, callback?: ErrorCallback): undefined;
+      delete_user(distinctId: DistinctId, callback: ErrorCallback): undefined;
+    }
+  }
+
+  export = mixpanel;
+}

--- a/lib/mixpanel-node.d.ts
+++ b/lib/mixpanel-node.d.ts
@@ -1,8 +1,8 @@
 declare const mixpanel: mixpanel.Mixpanel;
 
 declare namespace mixpanel {
-  export type ErrorCallback = (err: Error | undefined) => any;
-  export type ErrorsCallback = (errors: [Error] | undefined) => any;
+  export type Callback = (err: Error | undefined) => any;
+  export type BatchCallback = (errors: [Error] | undefined) => any;
 
   type Scalar = string | number | boolean;
 
@@ -41,120 +41,120 @@ declare namespace mixpanel {
   interface Mixpanel {
     init(mixpanelToken: string, config?: InitConfig): Mixpanel;
 
-    track(eventName: string, callback?: ErrorCallback): undefined;
-    track(eventName: string, properties: PropertyDict, callback?: ErrorCallback): undefined;
+    track(eventName: string, callback?: Callback): undefined;
+    track(eventName: string, properties: PropertyDict, callback?: Callback): undefined;
 
-    track_batch(events: Event[], options?: BatchOptions, callback?: ErrorsCallback): undefined;
-    track_batch(events: Event[], callback: ErrorsCallback): undefined;
-    track_batch(eventNames: string[], options?: BatchOptions, callback?: ErrorsCallback): undefined;
-    track_batch(eventNames: string[], callback?: ErrorsCallback): undefined;
+    track_batch(events: Event[], options?: BatchOptions, callback?: BatchCallback): undefined;
+    track_batch(events: Event[], callback: BatchCallback): undefined;
+    track_batch(eventNames: string[], options?: BatchOptions, callback?: BatchCallback): undefined;
+    track_batch(eventNames: string[], callback?: BatchCallback): undefined;
 
-    import(eventName: string, time: Date | number, properties?: PropertyDict, callback?: ErrorCallback): undefined;
-    import(eventName: string, time: Date | number, callback: ErrorCallback): undefined;
+    import(eventName: string, time: Date | number, properties?: PropertyDict, callback?: Callback): undefined;
+    import(eventName: string, time: Date | number, callback: Callback): undefined;
 
-    import_batch(eventNames: string[], options?: BatchOptions, callback?: ErrorsCallback): undefined;
-    import_batch(eventNames: string[], callback?: ErrorsCallback): undefined;
-    import_batch(events: Event[], callback?: ErrorsCallback): undefined;
+    import_batch(eventNames: string[], options?: BatchOptions, callback?: BatchCallback): undefined;
+    import_batch(eventNames: string[], callback?: BatchCallback): undefined;
+    import_batch(events: Event[], callback?: BatchCallback): undefined;
 
-    alias(distinctId: string, alias: string, callback?: ErrorCallback): undefined;
+    alias(distinctId: string, alias: string, callback?: Callback): undefined;
 
     people: People;
   }
 
   interface People {
-    set(distinctId: string, properties: PropertyDict, callback?: ErrorCallback): undefined;
+    set(distinctId: string, properties: PropertyDict, callback?: Callback): undefined;
     set(
       distinctId: string,
       properties: PropertyDict,
       modifiers?: Modifiers,
-      callback?: ErrorCallback,
+      callback?: Callback,
     ): undefined;
     set(distinctId: string, propertyName: string, value: string | number, modifiers: Modifiers): undefined;
-    set(distinctId: string, propertyName: string, value: string | number, callback?: ErrorCallback): undefined;
+    set(distinctId: string, propertyName: string, value: string | number, callback?: Callback): undefined;
     set(
       distinctId: string,
       propertyName: string,
       value: string | number,
       modifiers: Modifiers,
-      callback: ErrorCallback,
+      callback: Callback,
     ): undefined;
 
-    set_once(distinctId: string, propertyName: string, value: string, callback?: ErrorCallback): undefined;
+    set_once(distinctId: string, propertyName: string, value: string, callback?: Callback): undefined;
     set_once(
       distinctId: string,
       propertyName: string,
       value: string,
       modifiers: Modifiers,
-      callback?: ErrorCallback,
+      callback?: Callback,
     ): undefined;
-    set_once(distinctId: string, properties: PropertyDict, callback?: ErrorCallback): undefined;
+    set_once(distinctId: string, properties: PropertyDict, callback?: Callback): undefined;
     set_once(
       distinctId: string,
       properties: PropertyDict,
       modifiers?: Modifiers,
-      callback?: ErrorCallback,
+      callback?: Callback,
     ): undefined;
 
     increment(
       distinctId: string,
       propertyName: string,
       modifiers?: Modifiers,
-      callback?: ErrorCallback,
+      callback?: Callback,
     ): undefined;
     increment(
       distinctId: string,
       propertyName: string,
       incrementBy: number,
       modifiers: Modifiers,
-      callback?: ErrorCallback,
+      callback?: Callback,
     ): undefined;
-    increment(distinctId: string, propertyName: string, incrementBy: number, callback?: ErrorCallback): undefined;
+    increment(distinctId: string, propertyName: string, incrementBy: number, callback?: Callback): undefined;
     increment(
       distinctId: string,
       properties: NumberMap,
       modifiers: Modifiers,
-      callback?: ErrorCallback,
+      callback?: Callback,
     ): undefined;
-    increment(distinctId: string, properties: NumberMap, callback?: ErrorCallback): undefined;
+    increment(distinctId: string, properties: NumberMap, callback?: Callback): undefined;
 
     append(
       distinctId: string,
       propertyName: string,
       value: any,
       modifiers: Modifiers,
-      callback?: ErrorCallback,
+      callback?: Callback,
     ): undefined;
-    append(distinctId: string, propertyName: string, value: any, callback?: ErrorCallback): undefined;
-    append(distinctId: string, properties: PropertyDict, callback?: ErrorCallback): undefined;
+    append(distinctId: string, propertyName: string, value: any, callback?: Callback): undefined;
+    append(distinctId: string, properties: PropertyDict, callback?: Callback): undefined;
     append(
       distinctId: string,
       properties: PropertyDict,
       modifiers: Modifiers,
-      callback?: ErrorCallback,
+      callback?: Callback,
     ): undefined;
 
-    union(distinctId: string, data: UnionData, modifiers?: Modifiers, callback?: ErrorCallback): undefined;
-    union(distinctId: string, data: UnionData, callback: ErrorCallback): undefined;
+    union(distinctId: string, data: UnionData, modifiers?: Modifiers, callback?: Callback): undefined;
+    union(distinctId: string, data: UnionData, callback: Callback): undefined;
 
     track_charge(
       distinctId: string,
       amount: number | string,
       properties?: PropertyDict,
-      callback?: ErrorCallback,
+      callback?: Callback,
     ): undefined;
     track_charge(
       distinctId: string,
       amount: number | string,
       properties: PropertyDict,
       modifiers?: Modifiers,
-      callback?: ErrorCallback,
+      callback?: Callback,
     ): undefined;
 
-    clear_charges(distinctId: string, modifiers?: Modifiers, callback?: ErrorCallback): undefined;
-    clear_charges(distinctId: string, callback: ErrorCallback): undefined;
+    clear_charges(distinctId: string, modifiers?: Modifiers, callback?: Callback): undefined;
+    clear_charges(distinctId: string, callback: Callback): undefined;
 
-    delete_user(distinctId: string, modifiers?: Modifiers, callback?: ErrorCallback): undefined;
-    delete_user(distinctId: string, callback: ErrorCallback): undefined;
+    delete_user(distinctId: string, modifiers?: Modifiers, callback?: Callback): undefined;
+    delete_user(distinctId: string, callback: Callback): undefined;
   }
 }
 

--- a/lib/mixpanel-node.d.ts
+++ b/lib/mixpanel-node.d.ts
@@ -6,7 +6,7 @@ declare namespace mixpanel {
 
   type Scalar = string | number | boolean;
 
-  export interface PropertyMap {
+  export interface PropertyDict {
     [key: string]: any;
   }
 
@@ -16,7 +16,7 @@ declare namespace mixpanel {
 
   export interface Event {
     event: string;
-    properties: PropertyMap;
+    properties: PropertyDict;
   }
   export interface Modifiers {
     $ip?: string;
@@ -35,7 +35,7 @@ declare namespace mixpanel {
   }
 
   interface Mixpanel {
-    init(mixpanelToken: string, config?: PropertyMap): Mixpanel;
+    init(mixpanelToken: string, config?: PropertyDict): Mixpanel;
 
     track(eventName: string, callback?: ErrorCallback): undefined;
     track(eventName: string, properties: Object, callback?: ErrorCallback): undefined;
@@ -58,10 +58,10 @@ declare namespace mixpanel {
   }
 
   interface People {
-    set(distinctId: string, properties: PropertyMap, callback?: ErrorCallback): undefined;
+    set(distinctId: string, properties: PropertyDict, callback?: ErrorCallback): undefined;
     set(
       distinctId: string,
-      properties: PropertyMap,
+      properties: PropertyDict,
       modifiers?: Modifiers,
       callback?: ErrorCallback,
     ): undefined;
@@ -83,10 +83,10 @@ declare namespace mixpanel {
       modifiers: Modifiers,
       callback?: ErrorCallback,
     ): undefined;
-    set_once(distinctId: string, properties: PropertyMap, callback?: ErrorCallback): undefined;
+    set_once(distinctId: string, properties: PropertyDict, callback?: ErrorCallback): undefined;
     set_once(
       distinctId: string,
-      properties: PropertyMap,
+      properties: PropertyDict,
       modifiers?: Modifiers,
       callback?: ErrorCallback,
     ): undefined;
@@ -121,10 +121,10 @@ declare namespace mixpanel {
       callback?: ErrorCallback,
     ): undefined;
     append(distinctId: string, propertyName: string, value: any, callback?: ErrorCallback): undefined;
-    append(distinctId: string, properties: PropertyMap, callback?: ErrorCallback): undefined;
+    append(distinctId: string, properties: PropertyDict, callback?: ErrorCallback): undefined;
     append(
       distinctId: string,
-      properties: PropertyMap,
+      properties: PropertyDict,
       modifiers: Modifiers,
       callback?: ErrorCallback,
     ): undefined;
@@ -135,13 +135,13 @@ declare namespace mixpanel {
     track_charge(
       distinctId: string,
       amount: number | string,
-      properties?: PropertyMap,
+      properties?: PropertyDict,
       callback?: ErrorCallback,
     ): undefined;
     track_charge(
       distinctId: string,
       amount: number | string,
-      properties: PropertyMap,
+      properties: PropertyDict,
       modifiers?: Modifiers,
       callback?: ErrorCallback,
     ): undefined;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "test": "nodeunit"
   },
+  "types": "./lib/mixpanel-node.d.ts",
   "devDependencies": {
     "nodeunit": "^0.9.1",
     "proxyquire": "^1.7.11",


### PR DESCRIPTION
Found out that what's published on npm as `@types/mixpanel` is in fact for the [mixpanel-browser](https://www.npmjs.com/package/mixpanel-browser) package and I couldn't find any type declarations for this node package.

This addition should make the lives of this package's users that also use TypeScript much nicer. Please let me know if you like the idea of having this live here next to the actual source code (IMO better than separating it out to the [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) repo.

I tried to cover all of the many overloads these functions have. Running the sample code in README / example.js validates against the TS definitions nicely, but there's a chance I did miss something that wasn't covered by example code.