### PR TITLE
Add path configuration value to client initialisation

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -44,7 +44,8 @@ var create_client = function(token, config) {
         debug: false,
         verbose: false,
         host: 'api.mixpanel.com',
-        protocol: 'https'
+        protocol: 'https',
+        path: '',
     };
 
     metrics.token = token;
@@ -110,7 +111,7 @@ var create_client = function(token, config) {
             query_params.test = 1;
         }
 
-        request_options.path = endpoint + "?" + querystring.stringify(query_params);
+        request_options.path = metrics.config.path + endpoint + "?" + querystring.stringify(query_params);
 
         request = request_lib.request(request_options, function(res) {
             var data = "";

--- a/test/config.js
+++ b/test/config.js
@@ -12,7 +12,8 @@ exports.config = {
             debug: false,
             verbose: false,
             host: 'api.mixpanel.com',
-            protocol: 'https'
+            protocol: 'https',
+            path: ''
         }, "default config is incorrect");
         test.done();
     },


### PR DESCRIPTION
The configuration passed in as part of the constructor is not considered at all, despite the typings implying they should be. I've also added a `path` attribute, which makes it easier for people (who like me) use `example.com/mixpanel`. 

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>