### PR TITLE
[Security patch] Apply MitM security patch from https-proxy-agent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -615,9 +615,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.0.tgz",
+      "integrity": "sha512-y4jAxNEihqvBI5F3SaO2rtsjIOnnNA8sEbuiP+UhJZJHeM2NRm6c09ax2tgqme+SgUUvjao2fJXF4h3D6Cb2HQ==",
       "requires": {
         "agent-base": "^4.3.0",
         "debug": "^3.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,9 +147,9 @@
       "dev": true
     },
     "agent-base": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
-      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -425,9 +425,9 @@
       "dev": true
     },
     "es6-promise": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "es6-promisify": {
       "version": "5.0.0",
@@ -615,11 +615,11 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
+      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
       "requires": {
-        "agent-base": "^4.1.0",
+        "agent-base": "^4.3.0",
         "debug": "^3.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "sinon": "^7.1.1"
   },
   "dependencies": {
-    "https-proxy-agent": "2.2.2"
+    "https-proxy-agent": "3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "sinon": "^7.1.1"
   },
   "dependencies": {
-    "https-proxy-agent": "2.2.1"
+    "https-proxy-agent": "2.2.2"
   }
 }


### PR DESCRIPTION
[https-proxy-agent](https://www.npmjs.com/package/https-proxy-agent) version 2.2.1 contains a [reported man-in-the-middle vulnerability](https://hackerone.com/reports/541502). A security patch [was issued](https://github.com/TooTallNate/node-https-proxy-agent/pull/77) and released in version 3.0.0.

This mejor version does not include breaking changes in the code but has removed support to legacy node engines (4,5,7). Code is still [tested on 6, 8, 10, 12.](https://github.com/TooTallNate/node-https-proxy-agent/blob/master/.github/workflows/test.yml#L12)

I would like to include this security patch here.

<details>
<summary>Version 3.0.0 release notes</summary>

> This release fixes the [MitM vulnerability reported via HackerOne](https://hackerone.com/reports/541502). It is a breaking change because Node 4, 5, and 7 are no longer tested in CI (note that Node 6 is still supported).
> 
> ### Major Changes
> 
> -   Remove Node 5 and 7 from Travis: [`590bc8b`](https://github.com/TooTallNate/node-https-proxy-agent/commit/590bc8bed1348de6543f8d34d482c7e12a0a21ae)
> -   Remove Node 4 from Travis: [`6c804a2`](https://github.com/TooTallNate/node-https-proxy-agent/commit/6c804a2c919b53d29030340da8b02fd8225fd258)
> 
> ### Minor Changes
> 
> -   Update `proxy` to v1.0.0: [`d0e3c18`](https://github.com/TooTallNate/node-https-proxy-agent/commit/d0e3c18079119057b05582cb72d4fda21dfc2546)
> -   Test on Node.js 10 and 12: [`3535951`](https://github.com/TooTallNate/node-https-proxy-agent/commit/3535951e482ea52af4888938f59649ed92e81b2b)
> -   Fix compatibility with Node.js >= 10.0.0: [#73](https://github.com/TooTallNate/node-https-proxy-agent/pull/73)
> -   Add `.editorconfig` file: [`06ead2f`](https://github.com/TooTallNate/node-https-proxy-agent/commit/06ead2fe61f8123fbcc876f975fa2a0896d5c232)
> -   Add `.eslintrc.js` file: [`ae53572`](https://github.com/TooTallNate/node-https-proxy-agent/commit/ae5357223f5f3b7e13a8f684715dc1e291fd4a7a)
> 
> ### Patches
> 
> -   Update README with correct `secureProxy` behavior: [#65](https://github.com/TooTallNate/node-https-proxy-agent/pull/65)
> -   Remove unreachable code: [`46aad09`](https://github.com/TooTallNate/node-https-proxy-agent/commit/46aad0988b471f042856436cf3192b0e09e36fe6)
> -   [TypeScript] Allow `port` to be a string: [#72](https://github.com/TooTallNate/node-https-proxy-agent/pull/72)
> -   Use an `EventEmitter` to replay failed proxy connect HTTP requests: [#77](https://github.com/TooTallNate/node-https-proxy-agent/pull/77)
> 
> ### Credits
> 
> Huge thanks to [@lpinca](https://github.com/lpinca), [@stoically](https://github.com/stoically), and [@zkochan](https://github.com/zkochan) for helping!

- [origin](https://github.com/TooTallNate/node-https-proxy-agent/releases/tag/3.0.0)

</details>

- [Complete changelog](https://github.com/TooTallNate/node-https-proxy-agent/compare/2.2.1...3.0.0)