### PR TITLE
Allow development events through config

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -40,7 +40,7 @@ var create_client = function(token, config) {
 
     const metrics = {
         token,
-        config: {...DEFAULT_CONFIG},
+        config: {...DEFAULT_CONFIG, ...config},
     };
 
     /**


### PR DESCRIPTION
The `config` parameter of `create_client` is not spread into the internal metrics config.

This prevents us from overwriting protocol in development. As a result events are not received by mixpanel. Also I cant turn on the debug / verbose flags to aid my debugging.