### PR TITLE
Default use keepAlive agent for sdk

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -12,10 +12,14 @@ const Buffer = require('buffer').Buffer;
 const http = require('http');
 const https = require('https');
 const HttpsProxyAgent = require('https-proxy-agent');
+const url = require('url');
 
 const {async_all, ensure_timestamp} = require('./utils');
 const {MixpanelGroups} = require('./groups');
 const {MixpanelPeople} = require('./people');
+
+const httpAgent = new http.Agent({keepAlive: true})
+const httpsAgent = new https.Agent({keepAlive: true})
 
 const DEFAULT_CONFIG = {
     test: false,
@@ -35,8 +39,11 @@ var create_client = function(token, config) {
     const MAX_BATCH_SIZE = 50;
     const TRACK_AGE_LIMIT = 60 * 60 * 24 * 5;
     const REQUEST_LIBS = {http, https};
+    const REQUEST_AGENTS = {http: httpAgent, https: httpsAgent};
     const proxyPath = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
-    const proxyAgent = proxyPath ? new HttpsProxyAgent(proxyPath) : null;
+    const proxyAgent = proxyPath? new HttpsProxyAgent(Object.assign(url.parse(proxyPath), {
+      keepAlive: true,
+    })) : null;
 
     const metrics = {
         token,
@@ -105,6 +112,8 @@ var create_client = function(token, config) {
 
         if (proxyAgent) {
             request_options.agent = proxyAgent;
+        } else {
+            request_options.agent = REQUEST_LIBS[metrics.config.protocol]
         }
 
         if (metrics.config.test) {

--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -113,7 +113,7 @@ var create_client = function(token, config) {
         if (proxyAgent) {
             request_options.agent = proxyAgent;
         } else {
-            request_options.agent = REQUEST_LIBS[metrics.config.protocol]
+            request_options.agent = REQUEST_AGENTS[metrics.config.protocol]
         }
 
         if (metrics.config.test) {


### PR DESCRIPTION
by default nodejs `http` module will establish new TCP connection to server with 

1. dns resolution -> getaddr call in system
2. make tcp handshake connection
3. use that socket for communication

current implementation without agent results in lots of `ENOTFOUND getaddr` error in the `dns` module internally used by node.js due to the limitations of file descriptor in OS level. (this happens only if end user sends lots of request concurrently like use-cases of bulk import / high concurrency endpoints used in node.js servers).

using `keepAlive` agent should be a common practice in node.js sdks.

reference:
https://github.com/stripe/stripe-node/blob/master/lib/net/NodeHttpClient.js#L8-L9
https://rakshanshetty.in/nodejs-http-keep-alive/

related PR:
https://github.com/mixpanel/mixpanel-node/pull/185