### PR TITLE
Add typescript types for InitConfig

### DIFF
--- a/lib/mixpanel-node.d.ts
+++ b/lib/mixpanel-node.d.ts
@@ -19,6 +19,7 @@ declare namespace mixpanel {
     protocol?: string;
     /* API pathname - defaults to `""` */
     path?: '';
+    /* request keepAlive setting - defaults to `true` */
     keepAlive?: boolean;
     /** Geolocate based on client IP (e.g. when running in Electron) - defaults to `false`. 
      * To supply the user's IP manually, set to false and provide the `$ip` property instead.

--- a/lib/mixpanel-node.d.ts
+++ b/lib/mixpanel-node.d.ts
@@ -7,7 +7,23 @@ declare namespace mixpanel {
   type Scalar = string | number | boolean;
 
   export interface InitConfig {
-    [key: string]: any;
+    /* Defaults to `false` */
+    test?: boolean;
+    /* Defaults to `false` */
+    debug?: boolean;
+    /* Enable verbose logging - defaults to `false` */
+    verbose?: boolean;
+    /* API hostname - defaults to `"api.mixpanel.com"` */
+    host?: string;
+    /* API protocol - defaults to `"https"` */
+    protocol?: string;
+    /* API pathname - defaults to `""` */
+    path?: '';
+    keepAlive?: boolean;
+    /** Geolocate based on client IP (e.g. when running in Electron) - defaults to `false`. 
+     * To supply the user's IP manually, set to false and provide the `$ip` property instead.
+     **/
+    geolocate?: false;
   }
 
   export interface PropertyDict {


### PR DESCRIPTION
Adds typescript types for `InitConfig` based on `DEFAULT_CONFIG` found in `mixpanel-node.js`