### PR TITLE
Custom logger support

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+test/
+.github/

--- a/lib/mixpanel-node.d.ts
+++ b/lib/mixpanel-node.d.ts
@@ -6,8 +6,24 @@ declare namespace mixpanel {
 
   type Scalar = string | number | boolean;
 
+  export interface CustomLogger {
+    trace(message?: any, ...optionalParams: any[]): void;
+    debug(message?: any, ...optionalParams: any[]): void;
+    info(message?: any, ...optionalParams: any[]): void;
+    warn(message?: any, ...optionalParams: any[]): void;
+    error(message?: any, ...optionalParams: any[]): void;
+  }
+
   export interface InitConfig {
-    [key: string]: any;
+    test: boolean;
+    debug: boolean;
+    verbose: boolean;
+    host: string;
+    protocol: string;
+    path: string;
+    keepAlive: boolean;
+    geolocate: boolean;
+    logger: CustomLogger;
   }
 
   export interface PropertyDict {
@@ -45,7 +61,7 @@ declare namespace mixpanel {
   }
 
   interface Mixpanel {
-    init(mixpanelToken: string, config?: InitConfig): Mixpanel;
+    init(mixpanelToken: string, config?: Partial<InitConfig>): Mixpanel;
 
     track(eventName: string, callback?: Callback): void;
     track(eventName: string, properties: PropertyDict, callback?: Callback): void;

--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -15,7 +15,7 @@ const HttpsProxyAgent = require('https-proxy-agent');
 const url = require('url');
 const packageInfo = require('../package.json')
 
-const {async_all, ensure_timestamp} = require('./utils');
+const {async_all, ensure_timestamp, assert_logger} = require('./utils');
 const {MixpanelGroups} = require('./groups');
 const {MixpanelPeople} = require('./people');
 
@@ -30,6 +30,7 @@ const DEFAULT_CONFIG = {
     // set this to true to automatically geolocate based on the client's ip.
     // e.g., when running under electron
     geolocate: false,
+    logger: console,
 };
 
 var create_client = function(token, config) {
@@ -152,7 +153,7 @@ var create_client = function(token, config) {
 
         request.on('error', function(e) {
             if (metrics.config.debug) {
-                console.log("Got Error: " + e.message);
+                metrics.config.logger.error("Got Error: " + e.message);
             }
             callback(e);
         });
@@ -181,7 +182,7 @@ var create_client = function(token, config) {
         };
 
         if (metrics.config.debug) {
-            console.log("Sending the following event to Mixpanel:\n", data);
+            metrics.config.logger.debug("Sending the following event to Mixpanel", { data });
         }
 
         metrics.send_request({ method: "GET", endpoint: endpoint, data: data }, callback);
@@ -269,7 +270,7 @@ var create_client = function(token, config) {
         send_next_request_batch(0);
 
         if (metrics.config.debug) {
-            console.log(
+            metrics.config.logger.debug(
                 "Sending " + event_list.length + " events to Mixpanel in " +
                 total_event_batches + " batches of events and " +
                 total_request_batches + " batches of requests"
@@ -446,6 +447,9 @@ var create_client = function(token, config) {
                             mixpanel client config
     */
     metrics.set_config = function(config) {
+        if (config && config.logger !== undefined) {
+            assert_logger(config.logger);
+        }
         Object.assign(metrics.config, config);
         if (config.host) {
             // Split host into host and port

--- a/lib/people.js
+++ b/lib/people.js
@@ -81,8 +81,10 @@ class MixpanelPeople extends ProfileHelpers() {
             for (const [key, val] of Object.entries(prop)) {
                 if (isNaN(parseFloat(val))) {
                     if (this.mixpanel.config.debug) {
-                        console.error("Invalid increment value passed to mixpanel.people.increment - must be a number");
-                        console.error("Passed " + key + ":" + val);
+                        this.mixpanel.config.logger.error(
+                            "Invalid increment value passed to mixpanel.people.increment - must be a number",
+                            {key, value: val}
+                        );
                     }
                 } else {
                     $add[key] = val;
@@ -114,8 +116,7 @@ class MixpanelPeople extends ProfileHelpers() {
         data = merge_modifiers(data, modifiers);
 
         if (this.mixpanel.config.debug) {
-            console.log("Sending the following data to Mixpanel (Engage):");
-            console.log(data);
+            this.mixpanel.config.logger.debug("Sending the following data to Mixpanel (Engage)", { data });
         }
 
         this.mixpanel.send_request({ method: "GET", endpoint: "/engage", data: data }, callback);
@@ -168,8 +169,7 @@ class MixpanelPeople extends ProfileHelpers() {
         data = merge_modifiers(data, modifiers);
 
         if (this.mixpanel.config.debug) {
-            console.log("Sending the following data to Mixpanel (Engage):");
-            console.log(data);
+            this.mixpanel.config.logger.debug("Sending the following data to Mixpanel (Engage)", { data });
         }
 
         this.mixpanel.send_request({ method: "GET", endpoint: "/engage", data: data }, callback);
@@ -209,7 +209,7 @@ class MixpanelPeople extends ProfileHelpers() {
         if (typeof(amount) !== 'number') {
             amount = parseFloat(amount);
             if (isNaN(amount)) {
-                console.error("Invalid value passed to mixpanel.people.track_charge - must be a number");
+                this.mixpanel.config.logger.error("Invalid value passed to mixpanel.people.track_charge - must be a number");
                 return;
             }
         }
@@ -232,8 +232,7 @@ class MixpanelPeople extends ProfileHelpers() {
         data = merge_modifiers(data, modifiers);
 
         if (this.mixpanel.config.debug) {
-            console.log("Sending the following data to Mixpanel (Engage):");
-            console.log(data);
+            this.mixpanel.config.logger.debug("Sending the following data to Mixpanel (Engage)", { data });
         }
 
         this.mixpanel.send_request({ method: "GET", endpoint: "/engage", data: data }, callback);
@@ -260,7 +259,7 @@ class MixpanelPeople extends ProfileHelpers() {
         data = merge_modifiers(data, modifiers);
 
         if (this.mixpanel.config.debug) {
-            console.log("Clearing this user's charges:", distinct_id);
+            this.mixpanel.config.logger.debug("Clearing this user's charges", { '$distinct_id': distinct_id });
         }
 
         this.mixpanel.send_request({ method: "GET", endpoint: "/engage", data: data }, callback);

--- a/lib/profile_helpers.js
+++ b/lib/profile_helpers.js
@@ -76,8 +76,7 @@ exports.ProfileHelpers = (Base = Object) => class extends Base {
         data = merge_modifiers(data, modifiers);
 
         if (this.config.debug) {
-            console.log(`Sending the following data to Mixpanel (${this.endpoint}):`);
-            console.log(data);
+            this.mixpanel.config.logger.debug(`Sending the following data to Mixpanel (${this.endpoint})`, { data });
         }
 
         this.mixpanel.send_request({ method: "GET", endpoint: this.endpoint, data }, callback);
@@ -95,7 +94,7 @@ exports.ProfileHelpers = (Base = Object) => class extends Base {
         data = merge_modifiers(data, modifiers);
 
         if (this.config.debug) {
-            console.log(`Deleting profile ${JSON.stringify(identifiers)}`);
+            this.mixpanel.config.logger.debug('Deleting profile', { identifiers });
         }
 
         this.mixpanel.send_request({ method: "GET", endpoint: this.endpoint, data }, callback);
@@ -106,7 +105,7 @@ exports.ProfileHelpers = (Base = Object) => class extends Base {
 
         if (typeof(data) !== 'object' || util.isArray(data)) {
             if (this.config.debug) {
-                console.error("Invalid value passed to #remove - data must be an object with scalar values");
+                this.mixpanel.config.logger.error("Invalid value passed to #remove - data must be an object with scalar values");
             }
             return;
         }
@@ -116,8 +115,10 @@ exports.ProfileHelpers = (Base = Object) => class extends Base {
                 $remove[key] = val;
             } else {
                 if (this.config.debug) {
-                    console.error("Invalid argument passed to #remove - values must be scalar");
-                    console.error("Passed " + key + ':', val);
+                    this.mixpanel.config.logger.error(
+                        "Invalid argument passed to #remove - values must be scalar",
+                        { key, value: val }
+                    );
                 }
                 return;
             }
@@ -140,8 +141,10 @@ exports.ProfileHelpers = (Base = Object) => class extends Base {
         data = merge_modifiers(data, modifiers);
 
         if (this.config.debug) {
-            console.log(`Sending the following data to Mixpanel (${this.endpoint}):`);
-            console.log(data);
+            this.mixpanel.config.logger.debug(
+                `Sending the following data to Mixpanel (${this.endpoint})`,
+                { data }
+            );
         }
 
         this.mixpanel.send_request({ method: "GET", endpoint: this.endpoint, data }, callback);
@@ -152,7 +155,7 @@ exports.ProfileHelpers = (Base = Object) => class extends Base {
 
         if (typeof(data) !== 'object' || util.isArray(data)) {
             if (this.config.debug) {
-                console.error("Invalid value passed to #union - data must be an object with scalar or array values");
+                this.mixpanel.config.logger.error("Invalid value passed to #union - data must be an object with scalar or array values");
             }
             return;
         }
@@ -169,8 +172,10 @@ exports.ProfileHelpers = (Base = Object) => class extends Base {
                 $union[key] = [val];
             } else {
                 if (this.config.debug) {
-                    console.error("Invalid argument passed to #union - values must be a scalar value or array");
-                    console.error("Passed " + key + ':', val);
+                    this.mixpanel.config.logger.error(
+                        "Invalid argument passed to #union - values must be a scalar value or array",
+                        { key, value: val }
+                    );
                 }
             }
         }
@@ -192,8 +197,10 @@ exports.ProfileHelpers = (Base = Object) => class extends Base {
         data = merge_modifiers(data, modifiers);
 
         if (this.config.debug) {
-            console.log(`Sending the following data to Mixpanel (${this.endpoint}):`);
-            console.log(data);
+            this.mixpanel.config.logger.debug(
+                `Sending the following data to Mixpanel (${this.endpoint})`,
+                { data }
+            );
         }
 
         this.mixpanel.send_request({ method: "GET", endpoint: this.endpoint, data }, callback);
@@ -208,8 +215,10 @@ exports.ProfileHelpers = (Base = Object) => class extends Base {
             $unset = [prop];
         } else {
             if (this.config.debug) {
-                console.error("Invalid argument passed to #unset - must be a string or array");
-                console.error("Passed: " + prop);
+                this.mixpanel.config.logger.error(
+                    "Invalid argument passed to #unset - must be a string or array",
+                    { prop }
+                );
             }
             return;
         }
@@ -227,8 +236,10 @@ exports.ProfileHelpers = (Base = Object) => class extends Base {
         data = merge_modifiers(data, modifiers);
 
         if (this.config.debug) {
-            console.log(`Sending the following data to Mixpanel (${this.endpoint}):`);
-            console.log(data);
+            this.mixpanel.config.logger.debug(
+                `Sending the following data to Mixpanel (${this.endpoint})`,
+                { data }
+            );
         }
 
         this.mixpanel.send_request({ method: "GET", endpoint: this.endpoint, data }, callback);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -41,3 +41,21 @@ exports.ensure_timestamp = function(time) {
     }
     return time instanceof Date ? time.getTime() : time;
 };
+
+/**
+* Asserts that the provided logger object is valid
+* @param {CustomLogger} logger - The logger object to be validated
+* @throws {TypeError} If the logger object is not a valid Logger object or
+*   if it is missing any of the required methods
+*/
+exports.assert_logger = function(logger) {
+    if (typeof logger !== 'object') {
+        throw new TypeError(`"logger" must be a valid Logger object`);
+    }
+    
+    ['trace', 'debug', 'info', 'warn', 'error'].forEach((method) => {
+        if (typeof logger[method] !== 'function') {
+            throw new TypeError(`Logger object missing "${method}" method`);
+        }
+    });
+};

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,12 @@ var mixpanel = Mixpanel.init('<YOUR_TOKEN>', {
     keepAlive: false,
 });
 
+// pass the custom logger (default is console)
+var mixpanel = Mixpanel.init('<YOUR_TOKEN>', {
+    debug: true,
+    logger: pinoLogger, // or bunyan, or any other logger that implements the same interface
+});
+
 // track an event with optional properties
 mixpanel.track('my event', {
     distinct_id: 'some unique client id',

--- a/test/config.js
+++ b/test/config.js
@@ -16,6 +16,7 @@ exports.config = {
             path: '',
             keepAlive: true,
             geolocate: false,
+            logger: console,
         }, "default config is incorrect");
         test.done();
     },

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,0 +1,100 @@
+const Sinon = require('sinon');
+const Mixpanel = require('../lib/mixpanel-node');
+
+exports.logger = {
+    setUp: function(cb) {
+        this.consoleDebugFn = Sinon.stub(console, 'debug');
+
+        this.mixpanel = Mixpanel.init('test token');
+
+        this.mixpanel.send_request = () => {};
+
+        cb();
+    },
+
+    tearDown: function(next) {
+        this.consoleDebugFn.restore();
+
+        next();
+    },
+
+    "is default logger is console object": function(test) {
+        const loggerName = Object.prototype.toString.call(this.mixpanel.config.logger);
+        test.deepEqual(loggerName, '[object console]', "default logger is incorrect");
+        test.done();
+    },
+
+    "is throws an error on incorrect logger object": function(test) {
+        test.throws(
+            () => this.mixpanel.set_config({logger: false}),
+            TypeError,
+            "logger object must be a valid Logger object"
+        );
+        test.throws(
+            () => this.mixpanel.set_config({logger: {log: () => {}}}),
+            TypeError,
+            "logger object must be a valid Logger object"
+        );
+        test.done();
+    },
+
+    "is write log for track() method": function(test) {
+        this.mixpanel.set_config({debug: true});
+
+        this.mixpanel.track('test', {foo: 'bar'});
+
+        test.ok(
+            this.consoleDebugFn.calledOnce,
+            `debug() method wasn't called on default logger`
+        );
+
+        const [message] = this.consoleDebugFn.lastCall.args;
+
+        test.ok(
+            message.startsWith('Sending the following event'),
+            'incorrect argument was passed to debug() method'
+        );
+
+        test.done();
+    },
+
+    "is write log for increment() method": function(test) {
+        this.mixpanel.set_config({debug: true});
+
+        this.mixpanel.people.increment('bob', 'page_views', 1);
+
+        test.ok(
+            this.consoleDebugFn.calledOnce,
+            `debug() method wasn't called on default logger`
+        );
+
+        const [message] = this.consoleDebugFn.lastCall.args;
+
+        test.ok(
+            message.startsWith('Sending the following data'),
+            'incorrect argument was passed to debug() method'
+        );
+
+        test.done();
+    },
+
+    "is write log for remove() method": function(test) {
+        this.mixpanel.set_config({debug: true});
+
+        this.mixpanel.people.remove('bob', {'browsers': 'firefox'});
+
+        test.ok(
+            this.consoleDebugFn.calledOnce,
+            `debug() method wasn't called on default logger`
+        );
+
+        const [message] = this.consoleDebugFn.lastCall.args;
+
+        test.ok(
+            message.startsWith('Sending the following data'),
+            'incorrect argument was passed to debug() method'
+        );
+
+        test.done();
+    },
+};

--- a/test/logger.js
+++ b/test/logger.js
@@ -18,13 +18,13 @@ exports.logger = {
         next();
     },
 
-    "is default logger is console object": function(test) {
+    "defaults to console logger": function(test) {
         const loggerName = Object.prototype.toString.call(this.mixpanel.config.logger);
         test.deepEqual(loggerName, '[object console]', "default logger is incorrect");
         test.done();
     },
 
-    "is throws an error on incorrect logger object": function(test) {
+    "throws an error on incorrect logger object": function(test) {
         test.throws(
             () => this.mixpanel.set_config({logger: false}),
             TypeError,
@@ -38,7 +38,7 @@ exports.logger = {
         test.done();
     },
 
-    "is write log for track() method": function(test) {
+    "writes log for track() method": function(test) {
         this.mixpanel.set_config({debug: true});
 
         this.mixpanel.track('test', {foo: 'bar'});
@@ -58,7 +58,7 @@ exports.logger = {
         test.done();
     },
 
-    "is write log for increment() method": function(test) {
+    "writes log for increment() method": function(test) {
         this.mixpanel.set_config({debug: true});
 
         this.mixpanel.people.increment('bob', 'page_views', 1);
@@ -78,7 +78,7 @@ exports.logger = {
         test.done();
     },
 
-    "is write log for remove() method": function(test) {
+    "writes log for remove() method": function(test) {
         this.mixpanel.set_config({debug: true});
 
         this.mixpanel.people.remove('bob', {'browsers': 'firefox'});

--- a/test/logger.js
+++ b/test/logger.js
@@ -2,99 +2,208 @@ const Sinon = require('sinon');
 const Mixpanel = require('../lib/mixpanel-node');
 
 exports.logger = {
-    setUp: function(cb) {
-        this.consoleDebugFn = Sinon.stub(console, 'debug');
+    'console logger': {
+        setUp: function(cb) {
+            this.consoleDebugFn = Sinon.stub(console, 'debug');
 
-        this.mixpanel = Mixpanel.init('test token');
+            this.mixpanel = Mixpanel.init('test token');
 
-        this.mixpanel.send_request = () => {};
+            this.mixpanel.send_request = () => {};
 
-        cb();
+            cb();
+        },
+
+        tearDown: function(next) {
+            this.consoleDebugFn.restore();
+
+            next();
+        },
+
+        "defaults to console logger": function(test) {
+            const loggerName = Object.prototype.toString.call(this.mixpanel.config.logger);
+            test.deepEqual(loggerName, '[object console]', "default logger is incorrect");
+            test.done();
+        },
+
+        "throws an error on incorrect logger object": function(test) {
+            test.throws(
+                () => this.mixpanel.set_config({logger: false}),
+                TypeError,
+                "logger object must be a valid Logger object"
+            );
+            test.throws(
+                () => this.mixpanel.set_config({logger: {log: () => {}}}),
+                TypeError,
+                "logger object must be a valid Logger object"
+            );
+            test.done();
+        },
+
+        "writes log for track() method": function(test) {
+            this.mixpanel.set_config({debug: true});
+
+            this.mixpanel.track('test', {foo: 'bar'});
+
+            test.ok(
+                this.consoleDebugFn.calledOnce,
+                `debug() method wasn't called on default logger`
+            );
+
+            const [message] = this.consoleDebugFn.lastCall.args;
+
+            test.ok(
+                message.startsWith('Sending the following event'),
+                'incorrect argument was passed to debug() method'
+            );
+
+            test.done();
+        },
+
+        "writes log for increment() method": function(test) {
+            this.mixpanel.set_config({debug: true});
+
+            this.mixpanel.people.increment('bob', 'page_views', 1);
+
+            test.ok(
+                this.consoleDebugFn.calledOnce,
+                `debug() method wasn't called on default logger`
+            );
+
+            const [message] = this.consoleDebugFn.lastCall.args;
+
+            test.ok(
+                message.startsWith('Sending the following data'),
+                'incorrect argument was passed to debug() method'
+            );
+
+            test.done();
+        },
+
+        "writes log for remove() method": function(test) {
+            this.mixpanel.set_config({debug: true});
+
+            this.mixpanel.people.remove('bob', {'browsers': 'firefox'});
+
+            test.ok(
+                this.consoleDebugFn.calledOnce,
+                `debug() method wasn't called on default logger`
+            );
+
+            const [message] = this.consoleDebugFn.lastCall.args;
+
+            test.ok(
+                message.startsWith('Sending the following data'),
+                'incorrect argument was passed to debug() method'
+            );
+
+            test.done();
+        },
     },
+    'custom logger': {
+        setUp: function(cb) {
+            /**
+             * Custom logger must be an object with the following methods:
+             * 
+             * interface CustomLogger {
+             *     trace(message?: any, ...optionalParams: any[]): void;
+             *     debug(message?: any, ...optionalParams: any[]): void;
+             *     info(message?: any, ...optionalParams: any[]): void;
+             *     warn(message?: any, ...optionalParams: any[]): void;
+             *     error(message?: any, ...optionalParams: any[]): void;
+             * }
+             */
+            this.customLogger = {
+                trace: Sinon.stub(),
+                debug: Sinon.stub(),
+                info: Sinon.stub(),
+                warn: Sinon.stub(),
+                error: Sinon.stub(),
+            };
+            this.consoleDebugFn = Sinon.stub(console, 'debug');
 
-    tearDown: function(next) {
-        this.consoleDebugFn.restore();
+            this.mixpanel = Mixpanel.init('test token', {logger: this.customLogger});
 
-        next();
-    },
+            this.mixpanel.send_request = () => {};
 
-    "defaults to console logger": function(test) {
-        const loggerName = Object.prototype.toString.call(this.mixpanel.config.logger);
-        test.deepEqual(loggerName, '[object console]', "default logger is incorrect");
-        test.done();
-    },
+            cb();
+        },
 
-    "throws an error on incorrect logger object": function(test) {
-        test.throws(
-            () => this.mixpanel.set_config({logger: false}),
-            TypeError,
-            "logger object must be a valid Logger object"
-        );
-        test.throws(
-            () => this.mixpanel.set_config({logger: {log: () => {}}}),
-            TypeError,
-            "logger object must be a valid Logger object"
-        );
-        test.done();
-    },
+        tearDown: function(next) {
+            this.consoleDebugFn.restore();
 
-    "writes log for track() method": function(test) {
-        this.mixpanel.set_config({debug: true});
+            next();
+        },
 
-        this.mixpanel.track('test', {foo: 'bar'});
+        "writes log for track() method": function(test) {
+            this.mixpanel.set_config({debug: true});
 
-        test.ok(
-            this.consoleDebugFn.calledOnce,
-            `debug() method wasn't called on default logger`
-        );
+            this.mixpanel.track('test', {foo: 'bar'});
 
-        const [message] = this.consoleDebugFn.lastCall.args;
+            test.ok(
+                this.customLogger.debug.calledOnce,
+                `debug() method wasn't called on default logger`
+            );
+            test.ok(
+                !this.consoleDebugFn.calledOnce,
+                `console.debug() method was called while it shouldn't`
+            );
 
-        test.ok(
-            message.startsWith('Sending the following event'),
-            'incorrect argument was passed to debug() method'
-        );
+            const [message] = this.customLogger.debug.lastCall.args;
 
-        test.done();
-    },
+            test.ok(
+                message.startsWith('Sending the following event'),
+                'incorrect argument was passed to debug() method'
+            );
 
-    "writes log for increment() method": function(test) {
-        this.mixpanel.set_config({debug: true});
+            test.done();
+        },
 
-        this.mixpanel.people.increment('bob', 'page_views', 1);
+        "writes log for increment() method": function(test) {
+            this.mixpanel.set_config({debug: true});
 
-        test.ok(
-            this.consoleDebugFn.calledOnce,
-            `debug() method wasn't called on default logger`
-        );
+            this.mixpanel.people.increment('bob', 'page_views', 1);
 
-        const [message] = this.consoleDebugFn.lastCall.args;
+            test.ok(
+                this.customLogger.debug.calledOnce,
+                `debug() method wasn't called on default logger`
+            );
+            test.ok(
+                !this.consoleDebugFn.calledOnce,
+                `console.debug() method was called while it shouldn't`
+            );
 
-        test.ok(
-            message.startsWith('Sending the following data'),
-            'incorrect argument was passed to debug() method'
-        );
+            const [message] = this.customLogger.debug.lastCall.args;
 
-        test.done();
-    },
+            test.ok(
+                message.startsWith('Sending the following data'),
+                'incorrect argument was passed to debug() method'
+            );
 
-    "writes log for remove() method": function(test) {
-        this.mixpanel.set_config({debug: true});
+            test.done();
+        },
 
-        this.mixpanel.people.remove('bob', {'browsers': 'firefox'});
+        "writes log for remove() method": function(test) {
+            this.mixpanel.set_config({debug: true});
 
-        test.ok(
-            this.consoleDebugFn.calledOnce,
-            `debug() method wasn't called on default logger`
-        );
+            this.mixpanel.people.remove('bob', {'browsers': 'firefox'});
 
-        const [message] = this.consoleDebugFn.lastCall.args;
+            test.ok(
+                this.customLogger.debug.calledOnce,
+                `debug() method wasn't called on default logger`
+            );
+            test.ok(
+                !this.consoleDebugFn.calledOnce,
+                `console.debug() method was called while it shouldn't`
+            );
 
-        test.ok(
-            message.startsWith('Sending the following data'),
-            'incorrect argument was passed to debug() method'
-        );
+            const [message] = this.customLogger.debug.lastCall.args;
 
-        test.done();
+            test.ok(
+                message.startsWith('Sending the following data'),
+                'incorrect argument was passed to debug() method'
+            );
+
+            test.done();
+        },
     },
 };


### PR DESCRIPTION
Hi,

This PR is from a discussion in [this](https://github.com/mixpanel/mixpanel-node/issues/221) issue.

It adds support to pass a custom logger to the mixpanel instance. The custom logger should implement the following interface:
```ts
interface CustomLogger {
  trace(message?: any, ...optionalParams: any[]): void;
  debug(message?: any, ...optionalParams: any[]): void;
  info(message?: any, ...optionalParams: any[]): void;
  warn(message?: any, ...optionalParams: any[]): void;
  error(message?: any, ...optionalParams: any[]): void;
}
```

Here is an example output for the console logger, which will be used by default if no logger is passed:
```
Sending the following data to Mixpanel (/engage) {
  data: {
    '$token': 'TOKEN',
    '$distinct_id': 'ID',
    '$set': {
      foo: 'bar'
    }
  }
}
```

Here is an example output for the [pinojs](https://github.com/pinojs/pino) logger:
```
[1692475025041] DEBUG (API/10184 on Nicolle.local): Sending the following data to Mixpanel (/engage) {"data":{"$token":"TOKEN","$distinct_id":"ID","foo":"bar"}}}
```