### PR TITLE
fix: add missing config.secret to types

### DIFF
--- a/lib/mixpanel-node.d.ts
+++ b/lib/mixpanel-node.d.ts
@@ -21,6 +21,7 @@ declare namespace mixpanel {
     host: string;
     protocol: string;
     path: string;
+    secret: string;
     keepAlive: boolean;
     geolocate: boolean;
     logger: CustomLogger;


### PR DESCRIPTION
The release 0.18.0 broke the usage of this library using TypeScript and `secret` in the config:

```
error TS2345: Argument of type '{ host: string; secret: string; debug: boolean; }' is not assignable to parameter of type 'Partial<InitConfig>'.
Object literal may only specify known properties, and 'secret' does not exist in type 'Partial<InitConfig>'.
```
