### PR TITLE
:bug: Add secret option to InitConfig

### DIFF
--- a/lib/mixpanel-node.d.ts
+++ b/lib/mixpanel-node.d.ts
@@ -24,6 +24,7 @@ declare namespace mixpanel {
     keepAlive: boolean;
     geolocate: boolean;
     logger: CustomLogger;
+    secret: string;
   }
 
   export interface PropertyDict {


### PR DESCRIPTION
For certain functionality, like `import_batch`, a secret is needed. The type however, doesn't reflect this.

Ref: https://github.com/mixpanel/mixpanel-node/blob/d304d857553ee786984e3b764f3d2140196d2b62/example.js#L72