### PR TITLE
Add shutdown() and areFlagsReady() to feature flags providers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,9 +18,9 @@ jobs:
         node-version: [20.x, 22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci

--- a/lib/flags/flags.js
+++ b/lib/flags/flags.js
@@ -56,7 +56,7 @@ class FeatureFlagsProvider {
       const requestOptions = {
         host: this.providerConfig.api_host,
         port: 443,
-        path: path,
+        path,
         method: "GET",
         headers: {
           ...REQUEST_HEADERS,
@@ -113,6 +113,11 @@ class FeatureFlagsProvider {
   }
 
   /**
+   * No-op by default; subclasses can override to clean up resources
+   */
+  shutdown() {}
+
+  /**
    * Manually tracks a feature flag exposure event to Mixpanel
    * This provides flexibility for reporting individual exposure events when using getAllVariants
    * If using getVariantValue or getVariant, exposure events are tracked automatically by default.
@@ -137,7 +142,7 @@ class FeatureFlagsProvider {
       "Flag evaluation mode": this.evaluationMode,
     };
 
-    if (latencyMs !== null && latencyMs !== undefined) {
+    if (latencyMs != null) {
       properties["Variant fetch latency (ms)"] = latencyMs;
     }
 

--- a/lib/flags/local_flags.d.ts
+++ b/lib/flags/local_flags.d.ts
@@ -77,4 +77,14 @@ export default class LocalFeatureFlagsProvider {
    * @param context - Evaluation context (must include distinct_id)
    */
   getAllVariants(context: FlagContext): { [key: string]: SelectedVariant };
+
+  /**
+   * Stop polling and clean up resources
+   */
+  shutdown(): void;
+
+  /**
+   * Returns a promise that resolves when flag definitions have been fetched
+   */
+  areFlagsReady(): Promise<void>;
 }

--- a/lib/flags/local_flags.js
+++ b/lib/flags/local_flags.js
@@ -46,10 +46,7 @@ class LocalFeatureFlagsProvider extends FeatureFlagsProvider {
     this.config = mergedConfig;
     this.flagDefinitions = new Map();
     this.pollingInterval = null;
-
-    this._readyPromise = new Promise((resolve) => {
-      this._resolveReady = resolve;
-    });
+    this._initialFetchPromise = null;
   }
 
   /**
@@ -59,7 +56,8 @@ class LocalFeatureFlagsProvider extends FeatureFlagsProvider {
    */
   async startPollingForDefinitions() {
     try {
-      await this._fetchFlagDefinitions();
+      this._initialFetchPromise = this._fetchFlagDefinitions();
+      await this._initialFetchPromise;
 
       if (this.config.enable_polling && !this.pollingInterval) {
         this.pollingInterval = setInterval(async () => {
@@ -101,7 +99,12 @@ class LocalFeatureFlagsProvider extends FeatureFlagsProvider {
   }
 
   areFlagsReady() {
-    return this._readyPromise;
+    if (!this._initialFetchPromise) {
+      this.logger?.warn(
+        "areFlagsReady called before startPollingForDefinitions",
+      );
+    }
+    return this._initialFetchPromise ?? Promise.resolve();
   }
 
   /**
@@ -220,7 +223,6 @@ class LocalFeatureFlagsProvider extends FeatureFlagsProvider {
     });
 
     this.flagDefinitions = newDefinitions;
-    this._resolveReady();
 
     return response;
   }

--- a/lib/flags/local_flags.js
+++ b/lib/flags/local_flags.js
@@ -36,7 +36,7 @@ class LocalFeatureFlagsProvider extends FeatureFlagsProvider {
     };
 
     const providerConfig = {
-      token: token,
+      token,
       api_host: mergedConfig.api_host,
       request_timeout_in_seconds: mergedConfig.request_timeout_in_seconds,
     };
@@ -46,6 +46,10 @@ class LocalFeatureFlagsProvider extends FeatureFlagsProvider {
     this.config = mergedConfig;
     this.flagDefinitions = new Map();
     this.pollingInterval = null;
+
+    this._readyPromise = new Promise((resolve) => {
+      this._resolveReady = resolve;
+    });
   }
 
   /**
@@ -87,6 +91,17 @@ class LocalFeatureFlagsProvider extends FeatureFlagsProvider {
         "stopPollingForDefinitions called but polling was not active",
       );
     }
+  }
+
+  shutdown() {
+    if (this.pollingInterval) {
+      clearInterval(this.pollingInterval);
+      this.pollingInterval = null;
+    }
+  }
+
+  areFlagsReady() {
+    return this._readyPromise;
   }
 
   /**
@@ -205,6 +220,7 @@ class LocalFeatureFlagsProvider extends FeatureFlagsProvider {
     });
 
     this.flagDefinitions = newDefinitions;
+    this._resolveReady();
 
     return response;
   }
@@ -244,11 +260,11 @@ class LocalFeatureFlagsProvider extends FeatureFlagsProvider {
       return null;
     }
 
-    let selected_variant = this._getMatchingVariant(variantKey, flag);
-    if (selected_variant) {
-      selected_variant.is_qa_tester = true;
+    let selectedVariant = this._getMatchingVariant(variantKey, flag);
+    if (selectedVariant) {
+      selectedVariant.is_qa_tester = true;
     }
-    return selected_variant;
+    return selectedVariant;
   }
 
   _getAssignedRollout(flag, contextValue, context) {
@@ -256,7 +272,7 @@ class LocalFeatureFlagsProvider extends FeatureFlagsProvider {
       const rollout = flag.ruleset.rollout[index];
 
       let salt;
-      if (flag.hash_salt !== null && flag.hash_salt !== undefined) {
+      if (flag.hash_salt != null) {
         salt = flag.key + flag.hash_salt + index.toString();
       } else {
         salt = flag.key + "rollout";
@@ -286,10 +302,7 @@ class LocalFeatureFlagsProvider extends FeatureFlagsProvider {
       }
     }
 
-    const storedSalt =
-      flag.hash_salt !== null && flag.hash_salt !== undefined
-        ? flag.hash_salt
-        : "";
+    const storedSalt = flag.hash_salt != null ? flag.hash_salt : "";
     const salt = flagKey + storedSalt + "variant";
     const variantHash = normalizedHash(String(contextValue), salt);
 

--- a/lib/flags/remote_flags.d.ts
+++ b/lib/flags/remote_flags.d.ts
@@ -71,4 +71,9 @@ export default class RemoteFeatureFlagsProvider {
   getAllVariants(
     context: FlagContext,
   ): Promise<{ [key: string]: SelectedVariant } | null>;
+
+  /**
+   * Clean up resources (no-op for remote provider)
+   */
+  shutdown(): void;
 }


### PR DESCRIPTION
## Summary
- Adds `shutdown()` method to the base `FeatureFlagsProvider` class (no-op by default), with a concrete implementation in `LocalFeatureFlagsProvider` that stops polling
- Adds `areFlagsReady()` to `LocalFeatureFlagsProvider` which returns a promise that resolves when flag definitions have been fetched
- Adds TypeScript declarations for both new methods
- Minor code cleanups (shorthand properties, `!= null` simplification, variable renaming)

🤖 Generated with [Claude Code](https://claude.com/claude-code)