### PR TITLE
chore(openfeature): pin mixpanel ^0.23.0 for fallback_reason (SDK-126)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2239,7 +2239,7 @@
       }
     },
     "packages/mixpanel": {
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "MIT",
       "dependencies": {
         "https-proxy-agent": "7.0.6",
@@ -2264,7 +2264,7 @@
       },
       "peerDependencies": {
         "@openfeature/server-sdk": "^1.17.0",
-        "mixpanel": "^0.21.0"
+        "mixpanel": "^0.23.0"
       }
     }
   }

--- a/packages/openfeature-server-provider/package.json
+++ b/packages/openfeature-server-provider/package.json
@@ -16,7 +16,7 @@
   },
   "peerDependencies": {
     "@openfeature/server-sdk": "^1.17.0",
-    "mixpanel": "^0.21.0"
+    "mixpanel": "^0.23.0"
   },
   "devDependencies": {
     "@openfeature/core": "^1.9.2",


### PR DESCRIPTION
## Summary

`packages/openfeature-server-provider/src/MixpanelProvider.ts` dereferences `variant.fallback_reason`, added by #277 (SDK-79). That field first shipped in **mixpanel 0.23.0** — 0.22.0 was only the monorepo split and does not contain it.

The peerDep `mixpanel: ^0.21.0` allowed resolving against SDKs that predate `fallback_reason`, so the provider fell through to its legacy sentinel branch (`MixpanelProvider.ts:279`) and could never surface the specific fallback reason.

## Changes

- `packages/openfeature-server-provider/package.json`: bump peerDep `mixpanel: ^0.21.0` → `^0.23.0`
- `package-lock.json`: mirror the peerDep, and refresh the stale `packages/mixpanel` version (`0.22.0` → `0.23.0`) left over from the 0.23.0 release prep in #288

Why `^0.23.0` and not `^0.22.0`: npm caret ranges on `0.x` are minor-locked, so `^0.22.0` resolves to `>=0.22.0 <0.23.0` — it would have pinned to the one release lacking the field while *excluding* the release that has it.

## Release status

mixpanel `0.23.0` is already published (`latest` on npm), so no merge sequencing is needed and CI should pass on this branch as-is.

The wrapper version stays at `0.1.0`; the release-prep workflow owns that bump.

## Test plan

- [x] `npm ci` succeeds with the updated lockfile (CI uses `npm ci`)
- [x] `npm test` green — 278 mixpanel + 56 openfeature-server-provider tests pass
- [ ] Follow-up: remove the legacy-sentinel branch in `MixpanelProvider.ts` now that the peerDep excludes pre-SDK-79 mixpanel

Refs: [SDK-126](https://linear.app/mixpanel/issue/SDK-126), [SDK-79](https://linear.app/mixpanel/issue/SDK-79)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
