### PR TITLE
fix(analytics): keep polling when a flag-definition refresh fails

### DIFF
--- a/packages/mixpanel/lib/flags/local_flags.js
+++ b/packages/mixpanel/lib/flags/local_flags.js
@@ -96,17 +96,15 @@ class LocalFeatureFlagsProvider extends FeatureFlagsProvider {
           try {
             await this._fetchFlagDefinitions();
           } catch (err) {
-            // Stop polling on the first refresh failure and reset state
-            // (clears the interval and _startPromise) so the caller can
-            // decide to restart. Continuing to poll a failing endpoint
-            // just spams the log without recovering — if it's transient
-            // (network blip), a follow-up startPollingForDefinitions()
-            // gets us back; if it's permanent (bad token, revoked
-            // project), silent retries hide the real failure.
+            // Log and keep polling. A refresh failure is usually transient
+            // (network blip, HTTP 500) and the next tick recovers on its
+            // own. Tearing down the interval here would strand the provider
+            // on stale definitions indefinitely for the common case where
+            // the caller starts polling once at boot and never re-checks.
+            // Matches the Go/Python/Ruby/Java providers.
             this.logger?.error(
-              `Error polling for flag definitions, stopping polling: ${err.message}`,
+              `Error polling for flag definitions: ${err.message}`,
             );
-            this.stopPollingForDefinitions();
           }
         }, this.config.polling_interval_in_seconds * 1000);
       }

--- a/packages/mixpanel/test/flags/local_flags.js
+++ b/packages/mixpanel/test/flags/local_flags.js
@@ -1055,7 +1055,7 @@ describe("LocalFeatureFlagsProvider", () => {
       fetchSpy.mockRestore();
     });
 
-    it("stops polling and resets state when a refresh fails", async () => {
+    it("keeps polling when a refresh fails", async () => {
       // Capture the interval callback synchronously so we can drive it
       // directly without letting the real timer fire (and keep the test
       // deterministic).
@@ -1079,8 +1079,9 @@ describe("LocalFeatureFlagsProvider", () => {
         mockLogger,
       );
 
-      // Initial fetch succeeds so we get past _doStartPolling and set
-      // up the interval; second fetch (driven by the interval) fails.
+      // Initial fetch succeeds so we get past _doStartPolling and set up
+      // the interval; the next fetch (driven by the interval) fails, and
+      // the one after that succeeds again.
       nock("https://localhost")
         .get("/flags/definitions")
         .query(true)
@@ -1089,6 +1090,10 @@ describe("LocalFeatureFlagsProvider", () => {
         .get("/flags/definitions")
         .query(true)
         .reply(500);
+      nock("https://localhost")
+        .get("/flags/definitions")
+        .query(true)
+        .reply(200, { code: 200, flags: [] });
 
       await provider.startPollingForDefinitions();
       expect(provider.pollingInterval).not.toBeNull();
@@ -1098,12 +1103,18 @@ describe("LocalFeatureFlagsProvider", () => {
       // to reject and hit the catch.
       await intervalCallback();
 
-      expect(clearIntervalSpy).toHaveBeenCalledWith(999);
-      expect(provider.pollingInterval).toBeNull();
-      expect(provider._startPromise).toBeNull();
+      // The failure is logged but the interval survives, so a later tick
+      // can recover from a transient error.
+      expect(clearIntervalSpy).not.toHaveBeenCalled();
+      expect(provider.pollingInterval).toBe(999);
+      expect(provider._startPromise).not.toBeNull();
       expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining("stopping polling"),
+        expect.stringContaining("Error polling for flag definitions"),
       );
+
+      // Next tick succeeds — polling recovered on its own.
+      await intervalCallback();
+      expect(provider.pollingInterval).toBe(999);
 
       clearIntervalSpy.mockRestore();
       setIntervalSpy.mockRestore();


### PR DESCRIPTION
## Summary

Reverts the "stop polling on refresh failure" behavior added in the last commit of #278, while leaving the SDK-81 concurrent-start guard from that PR intact.

`LocalFeatureFlagsProvider`'s scheduled poll currently calls `stopPollingForDefinitions()` in its `catch`, tearing down the interval on the first failed refresh. The rationale in #278 was that a caller who sees the error can restart, and that silent retries hide permanent failures (revoked token, deleted project).

The common caller starts polling once at boot and never re-checks. Under the current behavior a single transient blip — a 500, a DNS hiccup — freezes flag definitions at their last-fetched values for the remaining life of the process, with one error line as the only signal. That converts a loud recoverable condition into a silent unrecoverable one, and it's exactly the failure mode long-running servers are least likely to notice.

It's also a cross-SDK divergence, called out as such in #278's own commit message. Go, Python, Ruby, and Java all log and continue:

- `mixpanel-go` `flags/localFlags.go` — `log.Printf("Error polling for flag definitions: %v", err)`, loop continues
- `mixpanel-ruby` `local_flags_provider.rb` — carries an explicit comment that a transient failure must **not** prevent polling
- Python and Java likewise

Node was the only outlier.

## Change

```diff
 } catch (err) {
-  this.logger?.error(
-    `Error polling for flag definitions, stopping polling: ${err.message}`,
-  );
-  this.stopPollingForDefinitions();
+  this.logger?.error(
+    `Error polling for flag definitions: ${err.message}`,
+  );
 }
```

The interval survives a failed tick and the next one recovers on its own. Permanent failures still log on every tick, which is the signal callers actually watch for.

## Tests

The pinning test `"stops polling and resets state when a refresh fails"` is retitled to `"keeps polling when a refresh fails"` and extended: after the failing tick it asserts `clearInterval` was **not** called, `pollingInterval` and `_startPromise` are intact, and a subsequent successful tick confirms recovery.

Full suite green — 278 base + 56 openfeature-provider tests, `tsc` clean, prettier clean, no new lint warnings.

## Release note

Worth landing before the `0.23.0` tag is pushed. `release: prepare analytics 0.23.0` (#288) is merged to `master` but `v0.23.0` is not tagged yet, so this can go out in the same release rather than as a follow-up patch.

Linear: SDK-81